### PR TITLE
Unlocked multiple issued documents

### DIFF
--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/model/RequestDocumentItemUi.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/model/RequestDocumentItemUi.kt
@@ -19,6 +19,7 @@ package eu.europa.ec.commonfeature.ui.request.model
 import eu.europa.ec.commonfeature.util.keyIsBase64
 import eu.europa.ec.eudi.iso18013.transfer.DocItem
 import eu.europa.ec.eudi.iso18013.transfer.DocRequest
+import eu.europa.ec.eudi.wallet.document.DocumentId
 import eu.europa.ec.eudi.wallet.document.ElementIdentifier
 
 data class RequestDocumentItemUi<T>(
@@ -79,5 +80,5 @@ fun <T> DocItem.toRequestDocumentItemUi(
     )
 }
 
-fun DocRequest.produceDocUID(elementIdentifier: ElementIdentifier): String =
-    docType + elementIdentifier
+fun DocRequest.produceDocUID(elementIdentifier: ElementIdentifier, documentId: DocumentId): String =
+    docType + elementIdentifier + documentId

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
@@ -99,7 +99,10 @@ object RequestTransformer {
                 ) {
                     required.add(
                         docItem.toRequestDocumentItemUi(
-                            uID = requestDocument.docRequest.produceDocUID(docItem.elementIdentifier),
+                            uID = requestDocument.docRequest.produceDocUID(
+                                docItem.elementIdentifier,
+                                requestDocument.documentId
+                            ),
                             docPayload = DocumentItemDomainPayload(
                                 docId = requestDocument.documentId,
                                 docRequest = requestDocument.docRequest,
@@ -115,7 +118,10 @@ object RequestTransformer {
                         )
                     )
                 } else {
-                    val uID = requestDocument.docRequest.produceDocUID(docItem.elementIdentifier)
+                    val uID = requestDocument.docRequest.produceDocUID(
+                        docItem.elementIdentifier,
+                        requestDocument.documentId
+                    )
 
                     items += RequestDataUi.Space()
                     items += RequestDataUi.OptionalField(

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/util/TestsData.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/util/TestsData.kt
@@ -46,6 +46,7 @@ object TestsData {
     )
 
     data class TestTransformedRequestDataUi(
+        val documentId: String,
         val documentTypeUi: DocumentTypeUi,
         val documentTitle: String,
         val optionalFields: List<TestFieldUi>,
@@ -460,6 +461,7 @@ object TestsData {
     )
 
     val mockedTransformedRequestDataUiForPidWithBasicFields = TestTransformedRequestDataUi(
+        documentId = mockedPidId,
         documentTypeUi = DocumentTypeUi.PID,
         documentTitle = mockedDocUiNamePid,
         optionalFields = mockedOptionalFieldsForPidWithBasicFields,
@@ -484,11 +486,13 @@ object TestsData {
             transformedRequestDataUi.optionalFields.forEachIndexed { index, testFieldUi ->
                 val optionalField = when (transformedRequestDataUi.documentTypeUi) {
                     DocumentTypeUi.PID -> mockCreateOptionalFieldForPid(
+                        docId = transformedRequestDataUi.documentId,
                         elementIdentifier = testFieldUi.elementIdentifier,
-                        value = testFieldUi.value,
+                        value = testFieldUi.value
                     )
 
                     DocumentTypeUi.MDL -> mockCreateOptionalFieldForMdl(
+                        docId = transformedRequestDataUi.documentId,
                         elementIdentifier = testFieldUi.elementIdentifier,
                         value = testFieldUi.value,
                     )
@@ -510,7 +514,8 @@ object TestsData {
             if (transformedRequestDataUi.requiredFields.isNotEmpty()) {
                 resultList.add(
                     mockCreateRequiredFieldsForPid(
-                        id = itemsIndex,
+                        docId = transformedRequestDataUi.documentId,
+                        requiredFieldsWholeSectionId = itemsIndex,
                         requiredFields = transformedRequestDataUi.requiredFields
                     )
                 )
@@ -522,6 +527,7 @@ object TestsData {
     }
 
     val mockedTransformedRequestDataUiForMdlWithBasicFields = TestTransformedRequestDataUi(
+        documentId = mockedMdlId,
         documentTypeUi = DocumentTypeUi.MDL,
         documentTitle = mockedDocUiNameMdl,
         optionalFields = mockedOptionalFieldsForMdlWithBasicFields,
@@ -529,12 +535,13 @@ object TestsData {
     )
 
     private fun mockCreateOptionalFieldForPid(
+        docId: String,
         elementIdentifier: String,
         value: String,
         checked: Boolean = true,
         enabled: Boolean = true,
     ): RequestDataUi.OptionalField<Event> {
-        val uniqueId = mockedPidDocType + elementIdentifier
+        val uniqueId = mockedPidDocType + elementIdentifier + docId
         return mockCreateOptionalField(
             documentTypeUi = DocumentTypeUi.PID,
             uniqueId = uniqueId,
@@ -547,12 +554,13 @@ object TestsData {
     }
 
     private fun mockCreateOptionalFieldForMdl(
+        docId: String,
         elementIdentifier: String,
         value: String,
         checked: Boolean = true,
         enabled: Boolean = true,
     ): RequestDataUi.OptionalField<Event> {
-        val uniqueId = mockedMdlDocType + elementIdentifier
+        val uniqueId = mockedMdlDocType + elementIdentifier + docId
         return mockCreateOptionalField(
             documentTypeUi = DocumentTypeUi.MDL,
             uniqueId = uniqueId,
@@ -642,12 +650,13 @@ object TestsData {
     }
 
     private fun mockCreateRequiredFieldsForPid(
-        id: Int,
+        docId: String,
+        requiredFieldsWholeSectionId: Int,
         requiredFields: List<TestFieldUi>,
     ): RequestDataUi.RequiredFields<Event> {
         val requestDocumentItemsUi: MutableList<RequestDocumentItemUi<Event>> = mutableListOf()
         requiredFields.forEach {
-            val uniqueId = mockedPidDocType + it.elementIdentifier
+            val uniqueId = mockedPidDocType + it.elementIdentifier + docId
             requestDocumentItemsUi.add(
                 mockCreateRequestDocumentItemUi(
                     documentTypeUi = DocumentTypeUi.PID,
@@ -663,11 +672,11 @@ object TestsData {
 
         return RequestDataUi.RequiredFields(
             requiredFieldsItemUi = RequiredFieldsItemUi(
-                id = id,
+                id = requiredFieldsWholeSectionId,
                 requestDocumentItemsUi = requestDocumentItemsUi,
                 expanded = false,
                 title = mockedRequestRequiredFieldsTitle,
-                event = Event.ExpandOrCollapseRequiredDataList(id = id)
+                event = Event.ExpandOrCollapseRequiredDataList(id = requiredFieldsWholeSectionId)
             )
         )
     }

--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/DashboardInteractor.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/DashboardInteractor.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import eu.europa.ec.businesslogic.config.ConfigLogic
 import eu.europa.ec.businesslogic.extension.safeAsync
 import eu.europa.ec.businesslogic.util.toDateFormatted
+import eu.europa.ec.commonfeature.model.DocumentTypeUi
 import eu.europa.ec.commonfeature.model.DocumentUi
 import eu.europa.ec.commonfeature.model.toDocumentTypeUi
 import eu.europa.ec.commonfeature.model.toUiName
@@ -74,6 +75,9 @@ class DashboardInteractorImpl(
         var userFirstName = ""
         var userImage = ""
         val documents = walletCoreDocumentsController.getAllDocuments()
+        val mainPid = documents
+            .filter { it.docType.toDocumentTypeUi() == DocumentTypeUi.PID }
+            .minByOrNull { it.createdAt }
         val documentsUi = documents.map { document ->
 
             var documentExpirationDate = extractValueFromDocumentOrEmpty(
@@ -91,14 +95,14 @@ class DashboardInteractorImpl(
 
             if (userFirstName.isBlank()) {
                 userFirstName = extractValueFromDocumentOrEmpty(
-                    document = document,
+                    document = mainPid ?: document,
                     key = DocumentJsonKeys.FIRST_NAME
                 )
             }
 
             if (userImage.isBlank()) {
                 userImage = extractValueFromDocumentOrEmpty(
-                    document = document,
+                    document = mainPid ?: document,
                     key = DocumentJsonKeys.PORTRAIT
                 )
             }

--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/DashboardInteractor.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/DashboardInteractor.kt
@@ -102,7 +102,7 @@ class DashboardInteractorImpl(
 
             if (userImage.isBlank()) {
                 userImage = extractValueFromDocumentOrEmpty(
-                    document = mainPid ?: document,
+                    document = document,
                     key = DocumentJsonKeys.PORTRAIT
                 )
             }

--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/document/AddDocumentInteractor.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/document/AddDocumentInteractor.kt
@@ -25,7 +25,6 @@ import eu.europa.ec.commonfeature.config.IssuanceFlowUiConfig
 import eu.europa.ec.commonfeature.interactor.DeviceAuthenticationInteractor
 import eu.europa.ec.commonfeature.model.DocumentOptionItemUi
 import eu.europa.ec.commonfeature.model.DocumentTypeUi
-import eu.europa.ec.commonfeature.model.toDocumentTypeUi
 import eu.europa.ec.commonfeature.model.toUiName
 import eu.europa.ec.corelogic.controller.AddSampleDataPartialState
 import eu.europa.ec.corelogic.controller.IssuanceMethod
@@ -75,7 +74,7 @@ class AddDocumentInteractorImpl(
                     text = DocumentTypeUi.PID.toUiName(resourceProvider),
                     icon = AppIcons.Id,
                     type = DocumentTypeUi.PID,
-                    available = !hasDocument(DocumentTypeUi.PID)
+                    available = true
                 ),
                 DocumentOptionItemUi(
                     text = DocumentTypeUi.MDL.toUiName(resourceProvider),
@@ -148,20 +147,6 @@ class AddDocumentInteractorImpl(
         }
     }
 
-    private fun hasDocument(documentTypeUi: DocumentTypeUi): Boolean {
-        val documents = walletCoreDocumentsController.getAllDocuments()
-        return if (documents.isNotEmpty()) {
-            documents.any { it.docType.toDocumentTypeUi() == documentTypeUi }
-        } else {
-            false
-        }
-    }
-
-    private fun canCreateMdl(flowType: IssuanceFlowUiConfig): Boolean {
-        return if (flowType == IssuanceFlowUiConfig.NO_DOCUMENT) {
-            false
-        } else {
-            !hasDocument(DocumentTypeUi.MDL)
-        }
-    }
+    private fun canCreateMdl(flowType: IssuanceFlowUiConfig): Boolean =
+        flowType != IssuanceFlowUiConfig.NO_DOCUMENT
 }

--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/document/DocumentDetailsInteractor.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/document/DocumentDetailsInteractor.kt
@@ -92,7 +92,23 @@ class DocumentDetailsInteractorImpl(
         documentType: String
     ): Flow<DocumentDetailsInteractorDeleteDocumentPartialState> =
         flow {
-            if (documentType.toDocumentTypeUi() == DocumentTypeUi.PID) {
+
+            val shouldDeleteAllDocuments: Boolean =
+                if (documentType.toDocumentTypeUi() == DocumentTypeUi.PID) {
+
+                    val allPidDocuments = walletCoreDocumentsController.getAllDocuments()
+                        .filter { it.docType.toDocumentTypeUi() == DocumentTypeUi.PID }
+
+                    if (allPidDocuments.count() > 1) {
+                        allPidDocuments.minByOrNull { it.createdAt }?.id == documentId
+                    } else {
+                        true
+                    }
+                } else {
+                    false
+                }
+
+            if (shouldDeleteAllDocuments) {
                 walletCoreDocumentsController.deleteAllDocuments(documentId = documentId).map {
                     when (it) {
                         is DeleteAllDocumentsPartialState.Failure -> DocumentDetailsInteractorDeleteDocumentPartialState.Failure(

--- a/presentation-feature/src/test/java/eu/europa/ec/presentationfeature/interactor/TestPresentationLoadingInteractor.kt
+++ b/presentation-feature/src/test/java/eu/europa/ec/presentationfeature/interactor/TestPresentationLoadingInteractor.kt
@@ -205,14 +205,14 @@ class TestPresentationLoadingInteractor {
 
     //region handleUserAuthentication
 
-    // Case 5:
+    // Case 1:
     // 1. deviceAuthenticationInteractor.getBiometricsAvailability returns:
     // BiometricsAvailability.CanAuthenticate
 
-    // Case 5 Expected Result:
+    // Case 1 Expected Result:
     // deviceAuthenticationInteractor.authenticateWithBiometrics called once.
     @Test
-    fun `Given case 5, When handleUserAuthentication is called, Then Case 5 expected result is returned`() {
+    fun `Given case 1, When handleUserAuthentication is called, Then Case 1 expected result is returned`() {
         // Given
         mockBiometricsAvailabilityResponse(
             response = BiometricsAvailability.CanAuthenticate
@@ -230,14 +230,14 @@ class TestPresentationLoadingInteractor {
             .authenticateWithBiometrics(context, crypto, resultHandler)
     }
 
-    // Case 6:
+    // Case 2:
     // 1. deviceAuthenticationInteractor.getBiometricsAvailability returns:
     // BiometricsAvailability.NonEnrolled
 
-    // Case 6 Expected Result:
+    // Case 2 Expected Result:
     // deviceAuthenticationInteractor.authenticateWithBiometrics called once.
     @Test
-    fun `Given case 6, When handleUserAuthentication is called, Then Case 6 expected result is returned`() {
+    fun `Given case 2, When handleUserAuthentication is called, Then Case 2 expected result is returned`() {
         // Given
         mockBiometricsAvailabilityResponse(
             response = BiometricsAvailability.NonEnrolled
@@ -255,14 +255,14 @@ class TestPresentationLoadingInteractor {
             .authenticateWithBiometrics(context, crypto, resultHandler)
     }
 
-    // Case 7:
+    // Case 3:
     // 1. deviceAuthenticationInteractor.getBiometricsAvailability returns:
     // BiometricsAvailability.Failure
 
-    // Case 7 Expected Result:
+    // Case 3 Expected Result:
     // resultHandler.onAuthenticationFailure called once.
     @Test
-    fun `Given case 7, When handleUserAuthentication is called, Then Case 7 expected result is returned`() {
+    fun `Given case 3, When handleUserAuthentication is called, Then Case 3 expected result is returned`() {
         // Given
         val mockedOnAuthenticationFailure: () -> Unit = {}
         whenever(resultHandler.onAuthenticationFailure)

--- a/proximity-feature/src/test/java/eu/europa/ec/proximityfeature/interactor/TestProximityRequestInteractor.kt
+++ b/proximity-feature/src/test/java/eu/europa/ec/proximityfeature/interactor/TestProximityRequestInteractor.kt
@@ -325,7 +325,7 @@ class TestProximityRequestInteractor {
     fun `Given Case 7, When getRequestDocuments is called, Then Case 7 Expected Result is returned`() {
         coroutineRule.runTest {
             // Given
-            mockGetAllDocumentsResponse(
+            mockGetAllDocumentsCall(
                 response = listOf(mockedPidWithBasicFields)
             )
             whenever(resourceProvider.getString(R.string.request_required_fields_title))
@@ -381,7 +381,7 @@ class TestProximityRequestInteractor {
     fun `Given Case 8, When getRequestDocuments is called, Then Case 8 Expected Result is returned`() {
         coroutineRule.runTest {
             // Given
-            mockGetAllDocumentsResponse(
+            mockGetAllDocumentsCall(
                 response = listOf(mockedMdlWithBasicFields)
             )
             whenever(resourceProvider.getString(R.string.request_required_fields_title))
@@ -437,7 +437,7 @@ class TestProximityRequestInteractor {
     fun `Given Case 9, When getRequestDocuments is called, Then Case 9 Expected Result is returned`() {
         coroutineRule.runTest {
             // Given
-            mockGetAllDocumentsResponse(
+            mockGetAllDocumentsCall(
                 response = listOf(
                     mockedMdlWithBasicFields,
                     mockedPidWithBasicFields
@@ -498,7 +498,7 @@ class TestProximityRequestInteractor {
     fun `Given Case 10, When getRequestDocuments is called, Then Case 10 Expected Result is returned`() {
         coroutineRule.runTest {
             // Given
-            mockGetAllDocumentsResponse(
+            mockGetAllDocumentsCall(
                 response = listOf(
                     mockedPidWithBasicFields,
                     mockedMdlWithBasicFields
@@ -703,7 +703,7 @@ class TestProximityRequestInteractor {
             )
     }
 
-    private fun mockGetAllDocumentsResponse(response: List<Document>) {
+    private fun mockGetAllDocumentsCall(response: List<Document>) {
         whenever(walletCoreDocumentsController.getAllDocuments())
             .thenReturn(response)
     }

--- a/test-feature/src/main/java/eu/europa/ec/testfeature/Constants.kt
+++ b/test-feature/src/main/java/eu/europa/ec/testfeature/Constants.kt
@@ -25,7 +25,9 @@ const val mockedPlainFailureMessage = "failure message"
 val mockedExceptionWithMessage = RuntimeException("Exception to test interactor.")
 val mockedExceptionWithNoMessage = RuntimeException()
 
+const val mockedOldestDocumentCreationDate = "2000-01-25T14:25:00.073Z"
 const val mockedDocumentCreationDate = "2024-01-25T14:25:00.073Z"
+const val mockedOldestPidId = "000000"
 const val mockedPidId = "000001"
 const val mockedMdlId = "000002"
 const val mockedPidDocName = "EU PID"
@@ -664,6 +666,11 @@ val mockedPidWithBasicFields = mockedFullPid.copy(
     nameSpacedData = mapOf(
         mockedPidCodeName to mockedPidBasicFields
     )
+)
+
+val mockedOldestPidWithBasicFields = mockedPidWithBasicFields.copy(
+    id = mockedOldestPidId,
+    createdAt = Instant.parse(mockedOldestDocumentCreationDate)
 )
 
 val mockedEmptyPid = mockedFullPid.copy(


### PR DESCRIPTION
1 . Removed limitation issuing multiple PIDs and MDLs, Document Details document deletion will now clear the storage only for the first PID issued (based on issuing timestamp).
2. Retrieve the username and image from the main PID for dashboard.
3. Fix broken tests for AddDocument and ProximityRequest Interactors.
4. Add some new tests for DocumentDetails Interactor.