### PR TITLE
Recalculate style of ScalableText when textStyle changes

### DIFF
--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/component/ScalableText.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/component/ScalableText.kt
@@ -41,7 +41,7 @@ fun ScalableText(
     modifier: Modifier = Modifier,
     maxLines: Int = 1,
 ) {
-    val style by remember(text) { mutableStateOf(textStyle) }
+    val style by remember(text, textStyle) { mutableStateOf(textStyle) }
     var readyToDraw by remember(text) { mutableStateOf(false) }
     var textSize by remember(text) { mutableStateOf(textStyle.fontSize) }
 


### PR DESCRIPTION
- The text style was not being recalculated when the textStyle changed, this commit fixes that by adding textStyle to the remember block.