### PR TITLE
Fix: Show Bottom Sheet for Success Deferred Docs, only if it is not o…

### DIFF
--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/dashboard/DashboardViewModel.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/dashboard/DashboardViewModel.kt
@@ -445,8 +445,10 @@ class DashboardViewModel(
                     is DashboardInteractorRetryIssuingDeferredDocumentsPartialState.Result -> {
                         val successDocs = response.successfullyIssuedDeferredDocuments
                         if (successDocs.isNotEmpty()
-                            && !viewState.value.isBottomSheetOpen
-                            && viewState.value.sheetContent is DashboardBottomSheetContent.DeferredDocumentsReady
+                            && (!viewState.value.isBottomSheetOpen
+                                    || (viewState.value.isBottomSheetOpen
+                                    && viewState.value.sheetContent !is DashboardBottomSheetContent.DeferredDocumentsReady)
+                                    )
                         ) {
                             showBottomSheet(
                                 sheetContent = DashboardBottomSheetContent.DeferredDocumentsReady(


### PR DESCRIPTION
…pen, or is open but for other Bottom Sheet Types/Content.