### PR TITLE
Refactor: Improve UI for filters in Documents Screen.

### DIFF
--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/DocumentsScreen.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/DocumentsScreen.kt
@@ -40,13 +40,17 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.LayoutDirection
@@ -78,7 +82,6 @@ import eu.europa.ec.uilogic.component.preview.ThemeModePreviews
 import eu.europa.ec.uilogic.component.utils.HSpacer
 import eu.europa.ec.uilogic.component.utils.LifecycleEffect
 import eu.europa.ec.uilogic.component.utils.OneTimeLaunchedEffect
-import eu.europa.ec.uilogic.component.utils.SPACING_EXTRA_LARGE
 import eu.europa.ec.uilogic.component.utils.SPACING_LARGE
 import eu.europa.ec.uilogic.component.utils.SPACING_MEDIUM
 import eu.europa.ec.uilogic.component.utils.SPACING_SMALL
@@ -413,12 +416,14 @@ private fun DocumentsSheetContent(
                         mutableStateOf(state.filtersUi.map { false }.toMutableStateList())
                     }
 
+                    var buttonsRowHeight by remember { mutableIntStateOf(0) }
+
                     Box {
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .verticalScroll(rememberScrollState())
-                                .padding(bottom = SPACING_EXTRA_LARGE.dp * 2),
+                                .padding(bottom = with(LocalDensity.current) { buttonsRowHeight.toDp() }),
                             verticalArrangement = Arrangement.spacedBy(SPACING_LARGE.dp)
                         ) {
                             DualSelectorButtons(state.sortOrder) {
@@ -447,23 +452,32 @@ private fun DocumentsSheetContent(
                                 .fillMaxWidth()
                                 .align(Alignment.BottomCenter)
                                 .background(MaterialTheme.colorScheme.surfaceContainerLowest)
+                                .onGloballyPositioned { coordinates ->
+                                    buttonsRowHeight = coordinates.size.height
+                                }
                                 .padding(top = SPACING_LARGE.dp),
                             horizontalArrangement = Arrangement.SpaceEvenly
                         ) {
                             WrapButton(
                                 modifier = Modifier.weight(1f),
-                                buttonConfig = ButtonConfig(type = ButtonType.SECONDARY, onClick = {
-                                    onEventSent(Event.OnFiltersReset)
-                                })
+                                buttonConfig = ButtonConfig(
+                                    type = ButtonType.SECONDARY,
+                                    onClick = {
+                                        onEventSent(Event.OnFiltersReset)
+                                    }
+                                )
                             ) {
                                 Text(text = stringResource(R.string.documents_screen_filters_reset))
                             }
                             HSpacer.Small()
                             WrapButton(
                                 modifier = Modifier.weight(1f),
-                                buttonConfig = ButtonConfig(type = ButtonType.PRIMARY, onClick = {
-                                    onEventSent(Event.OnFiltersApply)
-                                })
+                                buttonConfig = ButtonConfig(
+                                    type = ButtonType.PRIMARY,
+                                    onClick = {
+                                        onEventSent(Event.OnFiltersApply)
+                                    }
+                                )
                             ) {
                                 Text(text = stringResource(R.string.documents_screen_filters_apply))
                             }

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/component/DualSelectorButtons.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/component/DualSelectorButtons.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import eu.europa.ec.uilogic.component.preview.PreviewTheme
 import eu.europa.ec.uilogic.component.preview.ThemeModePreviews
@@ -121,6 +122,12 @@ fun RoundedBorderText(
     text: String,
     isSelected: Boolean,
 ) {
+    val contentColor = if (isSelected) {
+        MaterialTheme.colorScheme.onSecondaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -130,13 +137,14 @@ fun RoundedBorderText(
             WrapIcon(
                 modifier = Modifier.padding(end = SPACING_SMALL.dp),
                 iconData = AppIcons.Check,
-                customTint = MaterialTheme.colorScheme.onSurface
+                customTint = contentColor
             )
         }
         Text(
             text = text,
             style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurface
+            textAlign = TextAlign.Center,
+            color = contentColor
         )
     }
 }


### PR DESCRIPTION
# Description of changes
- Introduced a dynamically calculated bottom padding for the scrollable filter content in `DocumentsScreen` to prevent overlapping with the bottom action buttons.
- Applied `onGloballyPositioned` modifier to measure and set the height of the button row.
- Set the calculated height as the bottom padding of the scrollable content.
- Updated `DualSelectorButtons` to use appropriate `onSurface` and `onSecondaryContainer` colors based on selection status.
- Added `textAlign = TextAlign.Center` to the text within `DualSelectorButtons`.

## Type of change

Please delete options that are not relevant.

- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable