### PR TITLE
Add alternative method for self-signed certificate handling in development

### DIFF
--- a/core-logic/src/main/java/eu/europa/ec/corelogic/config/SslDevUtility.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/config/SslDevUtility.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.corelogic.util
+
+import android.annotation.SuppressLint
+import android.util.Log
+import java.security.SecureRandom
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Utility for configuring SSL trust settings in development environments.
+ * WARNING: Do not use in production as it disables certificate validation.
+ */
+object SslDevUtility {
+    private const val TAG = "SslDevUtility"
+    private var isInitialized = false
+
+    /**
+     * Configures the JVM to trust all SSL certificates.
+     * This should only be used in development/testing environments.
+     */
+    @SuppressLint("TrustAllX509TrustManager", "CustomX509TrustManager")
+    fun trustAllCertificates() {
+        if (isInitialized) {
+            Log.d(TAG, "SSL trust already initialized")
+            return
+        }
+
+        try {
+            val trustAllCerts = arrayOf<TrustManager>(
+                object : X509TrustManager {
+                    override fun checkClientTrusted(
+                        chain: Array<java.security.cert.X509Certificate>,
+                        authType: String
+                    ) {
+                        Log.d(TAG, "checkClientTrusted called for: $authType")
+                    }
+
+                    override fun checkServerTrusted(
+                        chain: Array<java.security.cert.X509Certificate>,
+                        authType: String
+                    ) {
+                        Log.d(TAG, "checkServerTrusted called for: $authType")
+                    }
+
+                    override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> {
+                        return arrayOf()
+                    }
+                }
+            )
+
+            // Create and initialize SSL context
+            val sslContext = SSLContext.getInstance("TLS")
+            sslContext.init(null, trustAllCerts, SecureRandom())
+
+            // Set as default SSL socket factory
+            HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.socketFactory)
+
+            // Set default hostname verifier to accept all hostnames
+            HttpsURLConnection.setDefaultHostnameVerifier { _, _ -> true }
+
+            isInitialized = true
+            Log.d(TAG, "SSL trust configuration initialized successfully")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to set up SSL trust configuration", e)
+        }
+    }
+}

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/di/LogicCoreModule.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/di/LogicCoreModule.kt
@@ -19,11 +19,13 @@ package eu.europa.ec.corelogic.di
 import android.content.Context
 import eu.europa.ec.businesslogic.controller.log.LogController
 import eu.europa.ec.corelogic.config.WalletCoreConfig
+import eu.europa.ec.corelogic.BuildConfig
 import eu.europa.ec.corelogic.config.WalletCoreConfigImpl
 import eu.europa.ec.corelogic.controller.WalletCoreDocumentsController
 import eu.europa.ec.corelogic.controller.WalletCoreDocumentsControllerImpl
 import eu.europa.ec.corelogic.controller.WalletCoreLogController
 import eu.europa.ec.corelogic.controller.WalletCoreLogControllerImpl
+import eu.europa.ec.corelogic.util.SslDevUtility
 import eu.europa.ec.eudi.wallet.EudiWallet
 import eu.europa.ec.resourceslogic.provider.ResourceProvider
 import org.koin.core.annotation.ComponentScan
@@ -45,6 +47,9 @@ fun provideEudiWallet(
     walletCoreConfig: WalletCoreConfig,
     walletCoreLogController: WalletCoreLogController
 ): EudiWallet = EudiWallet(context, walletCoreConfig.config) {
+    if (BuildConfig.DEBUG) {
+        SslDevUtility.trustAllCertificates()
+    }
     withLogger(walletCoreLogController)
 }
 

--- a/wiki/how_to_build.md
+++ b/wiki/how_to_build.md
@@ -170,3 +170,108 @@ This section describes configuring the application to interact with services uti
     ```
 
 For all configuration options please refer to [this document](configuration.md)
+
+### Method 2: Global SSL Trust Configuration
+
+> ⚠️ **NOTE**: If you encounter SSL handshake errors with Method 1, this alternative approach applies SSL trust settings globally.
+
+1. Create a new utility class `SslDevUtility.kt` in the `src/main/java/eu/europa/ec/corelogic/util` package:
+
+    ```Kotlin
+    package eu.europa.ec.corelogic.util
+
+    import android.annotation.SuppressLint
+    import android.util.Log
+    import java.security.SecureRandom
+    import javax.net.ssl.HostnameVerifier
+    import javax.net.ssl.HttpsURLConnection
+    import javax.net.ssl.SSLContext
+    import javax.net.ssl.TrustManager
+    import javax.net.ssl.X509TrustManager
+
+    /**
+     * Utility for configuring SSL trust settings in development environments.
+     * WARNING: Do not use in production as it disables certificate validation.
+     */
+    object SslDevUtility {
+        private const val TAG = "SslDevUtility"
+        private var isInitialized = false
+
+        /**
+         * Configures the JVM to trust all SSL certificates.
+         * This should only be used in development/testing environments.
+         */
+        @SuppressLint("TrustAllX509TrustManager", "CustomX509TrustManager")
+        fun trustAllCertificates() {
+            if (isInitialized) {
+                Log.d(TAG, "SSL trust already initialized")
+                return
+            }
+
+            try {
+                val trustAllCerts = arrayOf<TrustManager>(
+                    object : X509TrustManager {
+                        override fun checkClientTrusted(
+                            chain: Array<java.security.cert.X509Certificate>,
+                            authType: String
+                        ) {
+                            Log.d(TAG, "checkClientTrusted called for: $authType")
+                        }
+
+                        override fun checkServerTrusted(
+                            chain: Array<java.security.cert.X509Certificate>,
+                            authType: String
+                        ) {
+                            Log.d(TAG, "checkServerTrusted called for: $authType")
+                        }
+
+                        override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> {
+                            return arrayOf()
+                        }
+                    }
+                )
+
+                // Create and initialize SSL context
+                val sslContext = SSLContext.getInstance("TLS")
+                sslContext.init(null, trustAllCerts, SecureRandom())
+                
+                // Set as default SSL socket factory
+                HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.socketFactory)
+                
+                // Set default hostname verifier to accept all hostnames
+                HttpsURLConnection.setDefaultHostnameVerifier { _, _ -> true }
+                
+                isInitialized = true
+                Log.d(TAG, "SSL trust configuration initialized successfully")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to set up SSL trust configuration", e)
+            }
+        }
+    }
+    ```
+
+2. Update the `provideEudiWallet` function in `LogicCoreModule.kt` to use this utility in debug builds only:
+
+    ```Kotlin
+    @Single
+    fun provideEudiWallet(
+        context: Context,
+        walletCoreConfig: WalletCoreConfig,
+        walletCoreLogController: WalletCoreLogController
+    ): EudiWallet {
+        // Only enable SSL trust bypass in DEBUG builds
+        if (BuildConfig.DEBUG) {
+            SslDevUtility.trustAllCertificates()
+        }
+
+        return EudiWallet(context, walletCoreConfig.config) {
+            withLogger(walletCoreLogController)
+        }
+    }
+    ```
+This approach offers:
+- Works with all HTTP connections in the app, not just those created by Ktor
+- Only enabled in debug builds, ensuring it never affects production
+- Applies the trust settings at the JVM level
+
+You may choose either method based on your specific requirements


### PR DESCRIPTION
When following the current documentation for handling self-signed certificates, I encounter SSL handshake error:

`javax.net.ssl.SSLHandshakeException: java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.
`

The existing approach using ProvideKtorHttpClient doesn't work for me, I tried to update Issuer URI (as specified in Doc to local https), this MR introduces an additional method for handling self-signed certificates that complements the existing approach:
- Create a dedicated SslDevUtility class that applies SSL trust settings globally at the JVM level
- Add explicit conditional logic to only enable this in DEBUG builds
- Update documentation

As I said before, the ProvideKtorHttpClient is preserved and can be maintained for any future client-specific customizations that may be needed.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable