### PR TITLE
Refactor: Improve styling of WrapExpandableListItem

### DIFF
--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/component/wrap/WrapExpandableListItem.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/component/wrap/WrapExpandableListItem.kt
@@ -20,7 +20,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -89,8 +89,9 @@ fun WrapExpandableListItem(
                 clickableAreas = collapsedClickableAreas,
                 shape = RectangleShape,
                 colors = colors,
-                mainContentTextStyle = LocalTextStyle.current.copy(
-                    fontWeight = FontWeight.Bold
+                mainContentTextStyle = MaterialTheme.typography.bodyLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
             )
         },


### PR DESCRIPTION
# Description of changes
- Updated `WrapExpandableListItem` to use `MaterialTheme.typography.bodyLarge` with bold font weight and `onSurface` color for the main content text.
- Removed the use of `LocalTextStyle` for styling the main content.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable