### PR TITLE
Refactor: Update string retrieval in PrefsController

### DIFF
--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/storage/PrefsController.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/storage/PrefsController.kt
@@ -249,7 +249,7 @@ class PrefsControllerImpl(
      * key value is invalid.
      */
     override fun getString(key: String, defaultValue: String): String {
-        return getSharedPrefs().getString(key, defaultValue)?.unShuffle() ?: defaultValue
+        return getSharedPrefs().getString(key, null)?.unShuffle() ?: defaultValue
     }
 
     /**


### PR DESCRIPTION
Modified `getString` in `PrefsController` to return the `defaultValue` when the retrieved value is null, rather than only when the key-value pair is invalid. This is to correctly handle the case where a key is present but its associated value is null.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable