### PR TITLE
Refactor: Enhance transaction timestamp display

### DIFF
--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/util/DateHelper.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/util/DateHelper.kt
@@ -127,6 +127,10 @@ fun Instant.formatInstant(
     return formatter.format(this)
 }
 
+fun LocalDateTime.isJustNow(): Boolean {
+    return ChronoUnit.MINUTES.between(this, LocalDateTime.now()) == 0L
+}
+
 fun LocalDateTime.isWithinLastHour(): Boolean {
     return ChronoUnit.MINUTES.between(this, LocalDateTime.now()) < 60
 }

--- a/resources-logic/src/main/res/values/strings.xml
+++ b/resources-logic/src/main/res/values/strings.xml
@@ -280,7 +280,11 @@
     <string name="transactions_screen_search_label">Search Transactions</string>
     <string name="transactions_screen_search_no_results_id">noTransactionsId</string>
     <string name="transactions_screen_search_no_results">No transactions found. Try changing your search query or filters.</string>
-    <string name="transactions_screen_minutes_ago_message">%1$s minutes ago</string>
+    <string name="transactions_screen_0_minutes_ago_message">Just now</string>
+    <plurals name="transactions_screen_some_minutes_ago_message">
+        <item quantity="one">%d minute ago</item>
+        <item quantity="other">%d minutes ago</item>
+    </plurals>
     <string name="transactions_screen_text_field_date_pattern">dd/mm/yyyy</string>
 
     <!-- Transactions Screen, Filter labels-->


### PR DESCRIPTION
# Description of changes
- Added `isJustNow()` extension function to `LocalDateTime` in `DateHelper` to check if a date is within the last minute.
- Updated `TransactionsInteractor` to use `isJustNow()` for determining the "Just now" category.
- Added `JustNow` state in `TransactionInteractorDateTimeCategoryPartialState`.
- Replaced "X minutes ago" string with "Just now" and introduced `transactions_screen_some_minutes_ago_message` plural resource for better time display.
- Modified plural string for "minutes ago" to display one minute or multiple.
## Type of change

Please delete options that are not relevant.

- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable