### PR TITLE
feat: Move Revocation Interval to Wallet Core Configuration

### DIFF
--- a/assembly-logic/src/main/java/eu/europa/ec/assemblylogic/Application.kt
+++ b/assembly-logic/src/main/java/eu/europa/ec/assemblylogic/Application.kt
@@ -23,6 +23,7 @@ import androidx.work.WorkManager
 import eu.europa.ec.analyticslogic.controller.AnalyticsController
 import eu.europa.ec.assemblylogic.di.setupKoin
 import eu.europa.ec.businesslogic.config.ConfigLogic
+import eu.europa.ec.corelogic.config.WalletCoreConfig
 import eu.europa.ec.corelogic.worker.RevocationWorkManager
 import eu.europa.ec.eudi.rqesui.infrastructure.EudiRQESUi
 import org.koin.android.ext.android.inject
@@ -32,6 +33,7 @@ class Application : Application() {
 
     private val analyticsController: AnalyticsController by inject()
     private val configLogic: ConfigLogic by inject()
+    private val walletCoreConfig: WalletCoreConfig by inject()
 
     override fun onCreate() {
         super.onCreate()
@@ -60,7 +62,7 @@ class Application : Application() {
 
         val periodicWorkRequest = PeriodicWorkRequest.Builder(
             workerClass = RevocationWorkManager::class.java,
-            repeatInterval = configLogic.revocationInterval,
+            repeatInterval = walletCoreConfig.revocationInterval,
         ).build()
 
         WorkManager.getInstance(this).enqueueUniquePeriodicWork(

--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/config/ConfigLogic.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/config/ConfigLogic.kt
@@ -18,7 +18,6 @@ package eu.europa.ec.businesslogic.config
 
 import eu.europa.ec.businesslogic.BuildConfig
 import eu.europa.ec.eudi.rqesui.infrastructure.config.EudiRQESUiConfig
-import java.time.Duration
 
 interface ConfigLogic {
 
@@ -59,15 +58,6 @@ interface ConfigLogic {
      *   changelog is maintained for development builds.
      */
     val changelogUrl: String?
-
-
-    /**
-     * The interval at which revocations are checked.
-     *
-     * This property defines the time interval between checks for revoked tokens or credentials.
-     * It is currently set to 15 minutes.
-     */
-    val revocationInterval: Duration get() = Duration.ofMinutes(15)
 }
 
 enum class AppFlavor {

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/config/ConfigWalletCore.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/config/ConfigWalletCore.kt
@@ -20,10 +20,40 @@ import eu.europa.ec.corelogic.model.DocumentCategories
 import eu.europa.ec.corelogic.model.DocumentCategory
 import eu.europa.ec.corelogic.model.DocumentIdentifier
 import eu.europa.ec.eudi.wallet.EudiWalletConfig
+import java.time.Duration
 
 interface WalletCoreConfig {
+
+
+    /**
+     * Holds the configuration settings for the EudiWallet.
+     * This configuration includes settings such as API endpoints, cryptographic parameters,
+     * and storage locations.
+     */
     val config: EudiWalletConfig
 
+    /**
+     * Returns a predefined set of document categories and their associated identifiers.
+     *
+     * This property provides a structured mapping of common document categories (e.g., Government, Travel, Finance)
+     * to specific document identifiers.  These identifiers are used to uniquely identify different types of
+     * documents within a given category and are based on standard formats and specifications.
+     *
+     * The structure is a map where:
+     * - Keys are [DocumentCategory] enum values representing broad document types.
+     * - Values are lists of [DocumentIdentifier] objects, each representing a specific document type within that category.
+     *
+     * The supported document identifiers utilize various formats, including:
+     * - Predefined types like [DocumentIdentifier.MdocPid] and [DocumentIdentifier.SdJwtPid].
+     * - Formats defined by ISO standards (e.g., "org.iso.18013.5.1.mDL", "org.iso.23220.2.photoid.1").
+     * - Formats specified by the European Union (e.g., "eu.europa.ec.eudi.tax.1", "eu.europa.ec.eudi.iban.1").
+     * - URNs following the "urn:eu.europa.ec.eudi" namespace (e.g., "urn:eu.europa.ec.eudi:tax:1", "urn:eu.europa.ec.eudi:iban:1").
+     *
+     * The "Other" category is used for identifiers that don't fit neatly into the other predefined categories.
+     *
+     * Note:  An empty list for a category (e.g., Education) indicates that no specific document identifiers are
+     * currently defined for that category.
+     */
     val documentCategories: DocumentCategories
         get() = DocumentCategories(
             value = mapOf(
@@ -115,4 +145,12 @@ interface WalletCoreConfig {
                 ),
             )
         )
+
+    /**
+     * The interval at which revocations are checked.
+     *
+     * This property defines the time interval between checks for revoked tokens or credentials.
+     * It is currently set to 15 minutes.
+     */
+    val revocationInterval: Duration get() = Duration.ofMinutes(15)
 }


### PR DESCRIPTION
- Moved the `revocationInterval` configuration from `ConfigLogic` to `WalletCoreConfig`.
- Updated `RevocationWorkManager` to use `walletCoreConfig.revocationInterval` instead of `configLogic.revocationInterval`.
- Added documentation for `revocationInterval`, `documentCategories` and `config` in `WalletCoreConfig`.
- Added a set of document categories and their associated identifiers to the `documentCategories` in `WalletCoreConfig`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable