### PR TITLE
feat: Enhance Revocation Handling in WorkManager

### DIFF
--- a/core-logic/src/main/java/eu/europa/ec/corelogic/worker/RevocationWorkManager.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/worker/RevocationWorkManager.kt
@@ -79,7 +79,12 @@ class RevocationWorkManager(
                     walletCoreDocumentsController.resolveDocumentStatus(document).fold(
                         onSuccess = { status ->
                             when (status) {
-                                is Status.Invalid, Status.Suspended -> revokedDocuments.add(document)
+                                is Status.Invalid, Status.Suspended -> {
+                                    if (!storedRevokedDocuments.any { it == document.id }) {
+                                        revokedDocuments.add(document)
+                                    }
+                                }
+
                                 is Status.Valid -> {
                                     if (storedRevokedDocuments.any { it == document.id }) {
                                         fromRevokedToValid.add(document.id)


### PR DESCRIPTION
-   Added a check in `RevocationWorkManager` to avoid adding a document to `revokedDocuments` multiple times if it's already stored as revoked.
-   Modified the logic to only add a document to `revokedDocuments` if it's not present in `storedRevokedDocuments` when its status is `Invalid` or `Suspended`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable