### PR TITLE
Refactor: Update document details revoked message appearance

### DIFF
--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/detail/DocumentDetailsScreen.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/detail/DocumentDetailsScreen.kt
@@ -237,7 +237,10 @@ private fun Content(
                     modifier = Modifier
                         .fillMaxWidth(),
                     shape = MaterialTheme.shapes.small,
-                    colors = CardDefaults.cardColors(contentColor = MaterialTheme.colorScheme.errorContainer)
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer
+                    )
                 ) {
                     Column(
                         modifier = Modifier
@@ -248,8 +251,7 @@ private fun Content(
                                 R.string.document_details_revoked_document_message
                             ),
                             textConfig = TextConfig(
-                                color = MaterialTheme.colorScheme.error,
-                                style = MaterialTheme.typography.titleMedium,
+                                style = MaterialTheme.typography.bodyMedium,
                                 maxLines = Int.MAX_VALUE
                             )
                         )


### PR DESCRIPTION
- Updated the revoked document message card to use `errorContainer` as the background color and `onErrorContainer` as the content color.
- Adjusted the revoked message text style to `bodyMedium`.

# Description of changes
Add a description of the change here

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable