### PR TITLE
Update RQES-UI SDK to version 0.2.1

### DIFF
--- a/business-logic/src/demo/java/eu/europa/ec/businesslogic/config/RQESConfigImpl.kt
+++ b/business-logic/src/demo/java/eu/europa/ec/businesslogic/config/RQESConfigImpl.kt
@@ -22,20 +22,11 @@ import eu.europa.ec.eudi.rqes.HashAlgorithmOID
 import eu.europa.ec.eudi.rqesui.domain.extension.toUriOrEmpty
 import eu.europa.ec.eudi.rqesui.infrastructure.config.DocumentRetrievalConfig
 import eu.europa.ec.eudi.rqesui.infrastructure.config.EudiRQESUiConfig
-import eu.europa.ec.eudi.rqesui.infrastructure.config.RqesServiceConfig
 import eu.europa.ec.eudi.rqesui.infrastructure.config.data.QtspData
 import eu.europa.ec.resourceslogic.R
 import java.net.URI
 
 class RQESConfigImpl(val context: Context) : EudiRQESUiConfig {
-
-    override val rqesServiceConfig: RqesServiceConfig
-        get() = RqesServiceConfig(
-            clientId = "wallet-client",
-            clientSecret = "somesecret2",
-            authFlowRedirectionURI = URI.create(BuildConfig.RQES_DEEPLINK),
-            hashAlgorithm = HashAlgorithmOID.SHA_256,
-        )
 
     override val qtsps: List<QtspData>
         get() = listOf(
@@ -43,6 +34,10 @@ class RQESConfigImpl(val context: Context) : EudiRQESUiConfig {
                 name = "Wallet-Centric",
                 endpoint = "https://walletcentric.signer.eudiw.dev/csc/v2".toUriOrEmpty(),
                 scaUrl = "https://walletcentric.signer.eudiw.dev",
+                clientId = "wallet-client",
+                clientSecret = "somesecret2",
+                authFlowRedirectionURI = URI.create(BuildConfig.RQES_DEEPLINK),
+                hashAlgorithm = HashAlgorithmOID.SHA_256,
             )
         )
 

--- a/business-logic/src/dev/java/eu/europa/ec/businesslogic/config/RQESConfigImpl.kt
+++ b/business-logic/src/dev/java/eu/europa/ec/businesslogic/config/RQESConfigImpl.kt
@@ -22,20 +22,11 @@ import eu.europa.ec.eudi.rqes.HashAlgorithmOID
 import eu.europa.ec.eudi.rqesui.domain.extension.toUriOrEmpty
 import eu.europa.ec.eudi.rqesui.infrastructure.config.DocumentRetrievalConfig
 import eu.europa.ec.eudi.rqesui.infrastructure.config.EudiRQESUiConfig
-import eu.europa.ec.eudi.rqesui.infrastructure.config.RqesServiceConfig
 import eu.europa.ec.eudi.rqesui.infrastructure.config.data.QtspData
 import eu.europa.ec.resourceslogic.R
 import java.net.URI
 
 class RQESConfigImpl(val context: Context) : EudiRQESUiConfig {
-
-    override val rqesServiceConfig: RqesServiceConfig
-        get() = RqesServiceConfig(
-            clientId = "wallet-client",
-            clientSecret = "somesecret2",
-            authFlowRedirectionURI = URI.create(BuildConfig.RQES_DEEPLINK),
-            hashAlgorithm = HashAlgorithmOID.SHA_256,
-        )
 
     override val qtsps: List<QtspData>
         get() = listOf(
@@ -43,6 +34,10 @@ class RQESConfigImpl(val context: Context) : EudiRQESUiConfig {
                 name = "Wallet-Centric",
                 endpoint = "https://walletcentric.signer.eudiw.dev/csc/v2".toUriOrEmpty(),
                 scaUrl = "https://walletcentric.signer.eudiw.dev",
+                clientId = "wallet-client",
+                clientSecret = "somesecret2",
+                authFlowRedirectionURI = URI.create(BuildConfig.RQES_DEEPLINK),
+                hashAlgorithm = HashAlgorithmOID.SHA_256,
             )
         )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ sonar = "5.1.0.4882"
 baselineprofile = "1.3.4"
 timber = "5.0.1"
 treessence = "1.1.2"
-rqesUiSDK = "0.2.0"
+rqesUiSDK = "0.2.1"
 realm = "2.3.0"
 
 [libraries]


### PR DESCRIPTION
# Description of changes
This commit updates the RQES-UI SDK to version 0.2.1. 
The `RqesServiceConfig` has been removed and its properties are now part of `QtspData`.


## Type of change

Please delete options that are not relevant.
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable