### PR TITLE
Reactivate SD-JWT PID support

### DIFF
--- a/core-logic/src/main/java/eu/europa/ec/corelogic/controller/WalletCoreDocumentsController.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/controller/WalletCoreDocumentsController.kt
@@ -33,6 +33,7 @@ import eu.europa.ec.corelogic.model.ScopedDocument
 import eu.europa.ec.corelogic.model.TransactionLogData
 import eu.europa.ec.corelogic.model.toDocumentIdentifier
 import eu.europa.ec.eudi.openid4vci.MsoMdocCredential
+import eu.europa.ec.eudi.openid4vci.SdJwtVcCredential
 import eu.europa.ec.eudi.statium.Status
 import eu.europa.ec.eudi.wallet.EudiWallet
 import eu.europa.ec.eudi.wallet.document.DeferredDocument
@@ -239,8 +240,7 @@ class WalletCoreDocumentsControllerImpl(
 
                         val isPid: Boolean = when (config) {
                             is MsoMdocCredential -> config.docType.toDocumentIdentifier() == DocumentIdentifier.MdocPid
-                            // TODO: Re-activate once SD-JWT PID Rule book is in place in ARF.
-                            //is SdJwtVcCredential -> config.type.toDocumentIdentifier() == DocumentIdentifier.SdJwtPid
+                            is SdJwtVcCredential -> config.type.toDocumentIdentifier() == DocumentIdentifier.SdJwtPid
                             else -> false
                         }
 

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/model/DocumentIdentifier.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/model/DocumentIdentifier.kt
@@ -32,7 +32,7 @@ sealed interface DocumentIdentifier {
 
     data object SdJwtPid : DocumentIdentifier {
         override val formatType: FormatType
-            get() = "urn:eu.europa.ec.eudi:pid:1"
+            get() = "urn:eudi:pid:1"
     }
 
     data class OTHER(

--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/DocumentOfferInteractor.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/DocumentOfferInteractor.kt
@@ -158,9 +158,7 @@ class DocumentOfferInteractorImpl(
                             val hasPidInOffer =
                                 response.offer.offeredDocuments.any { offeredDocument ->
                                     val id = offeredDocument.documentIdentifier
-                                    // TODO: Re-activate once SD-JWT PID Rule book is in place in ARF.
-                                    // id == DocumentIdentifier.MdocPid || id == DocumentIdentifier.SdJwtPid
-                                    id == DocumentIdentifier.MdocPid
+                                    id == DocumentIdentifier.MdocPid || id == DocumentIdentifier.SdJwtPid
                                 }
 
                             if (hasMainPid || hasPidInOffer) {


### PR DESCRIPTION
This commit reactivates the support for SD-JWT PID by:

- Updating the format type for `SdJwtPid` in `DocumentIdentifier.kt` to `urn:eudi:pid:1`.
- Re-enabling the SD-JWT PID checks in `WalletCoreDocumentsController.kt` and `DocumentOfferInteractor.kt` that were previously commented out.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable