### PR TITLE
Refactor: Standardize package name for extensions and update Kover ex…

### DIFF
--- a/assembly-logic/build.gradle.kts
+++ b/assembly-logic/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     api(project(ProximityFeature.path))
     api(project(IssuanceFeature.path))
 
-    // Test Cover Report
+    // Modules Kover Report
     koverModules.forEach {
         kover(project(it.key.path)) {
             excludeFromKoverReport(
@@ -83,6 +83,7 @@ dependencies {
     }
 }
 
+// Current Module Kover Report
 excludeFromKoverReport(
     excludedClasses = KoverExclusionRules.AssemblyLogic.classes,
     excludedPackages = KoverExclusionRules.AssemblyLogic.packages,

--- a/build-logic/convention/src/main/kotlin/project/convention/logic/kover/KoverAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/project/convention/logic/kover/KoverAndroid.kt
@@ -24,7 +24,7 @@ fun Project.excludeFromKoverReport(
     excludedClasses: List<String>,
     excludedPackages: List<String>,
 ) {
-    extensions.configure<KoverProjectExtension> {
+    configure<KoverProjectExtension> {
         reports {
             filters {
                 excludes {

--- a/build-logic/convention/src/main/kotlin/project/convention/logic/kover/KoverExclusionRules.kt
+++ b/build-logic/convention/src/main/kotlin/project/convention/logic/kover/KoverExclusionRules.kt
@@ -22,6 +22,13 @@ private const val KOIN = "*.ksp.*"
 private const val BUILD_CONFIG = "*BuildConfig*"
 private const val SCREEN_COMPOSABLES = "*Screen*"
 private const val MODELS = "eu.europa.ec.*.model"
+private const val DOMAIN_MODELS = "eu.europa.ec.*.domain"
+private const val EXTENSIONS = "eu.europa.ec.*.extension"
+private const val CONFIGS = "eu.europa.ec.*.config"
+private const val TRANSFORMERS = "eu.europa.ec.*.transformer"
+private const val COMPONENTS = "eu.europa.ec.*.component"
+private const val UTILS = "eu.europa.ec.*.util"
+private const val PROVIDERS = "eu.europa.ec.*.provider"
 private const val DI = "eu.europa.ec.*.di"
 private const val ROUTER_GRAPH = "eu.europa.ec.*.router"
 
@@ -40,7 +47,7 @@ sealed interface KoverExclusionRules {
     val commonClasses: List<String>
         get() = listOf(
             BUILD_CONFIG,
-            SCREEN_COMPOSABLES,
+            SCREEN_COMPOSABLES
         )
 
     val commonPackages: List<String>
@@ -48,7 +55,14 @@ sealed interface KoverExclusionRules {
             KOIN,
             DI,
             MODELS,
+            DOMAIN_MODELS,
             ROUTER_GRAPH,
+            EXTENSIONS,
+            CONFIGS,
+            TRANSFORMERS,
+            UTILS,
+            COMPONENTS,
+            PROVIDERS
         )
 
     val classes: List<String>
@@ -69,23 +83,10 @@ sealed interface KoverExclusionRules {
 
     object BusinessLogic : LogicModule {
         override val classes: List<String>
-            get() = commonClasses + listOf(
-                "eu.europa.ec.businesslogic.controller.security.AntiHookController",
-                "eu.europa.ec.businesslogic.controller.security.RootController",
-                "eu.europa.ec.businesslogic.controller.security.AndroidInstaller",
-                "eu.europa.ec.businesslogic.controller.security.AndroidPackageController*",
-                "eu.europa.ec.businesslogic.controller.security.AntiHookController*",
-                "eu.europa.ec.businesslogic.controller.security.RootControllerImpl",
-                "eu.europa.ec.businesslogic.controller.security.SecurityErrorCode",
-                "eu.europa.ec.businesslogic.controller.security.SecurityValidation",
-                "eu.europa.ec.businesslogic.extension.FlowExtensions*",
-                "eu.europa.ec.businesslogic.util.EudiWalletListenerWrapper",
-                "eu.europa.ec.businesslogic.util.SafeLet*",
-            )
+            get() = commonClasses
 
         override val packages: List<String>
             get() = commonPackages + listOf(
-                "eu.europa.ec.businesslogic.config",
                 "eu.europa.ec.businesslogic.controller.crypto",
                 "eu.europa.ec.businesslogic.controller.log",
                 "eu.europa.ec.businesslogic.controller.storage"
@@ -94,21 +95,14 @@ sealed interface KoverExclusionRules {
 
     object UiLogic : LogicModule {
         override val classes: List<String>
-            get() = commonClasses + listOf(
-                "eu.europa.ec.uilogic.navigation.*Screen*",
-                "eu.europa.ec.uilogic.navigation.ModuleRoute*",
-                "eu.europa.ec.uilogic.navigation.RouterHost*",
-                "eu.europa.ec.uilogic.serializer.UiSerializableParser*",
-                "eu.europa.ec.uilogic.serializer.UiSerializerImpl",
-            )
+            get() = commonClasses
 
         override val packages: List<String>
             get() = commonPackages + listOf(
-                "eu.europa.ec.uilogic.component",
-                "eu.europa.ec.uilogic.config",
                 "eu.europa.ec.uilogic.container",
-                "eu.europa.ec.uilogic.extension",
                 "eu.europa.ec.uilogic.mvi",
+                "eu.europa.ec.uilogic.navigation",
+                "eu.europa.ec.uilogic.serializer",
             )
     }
 
@@ -124,15 +118,10 @@ sealed interface KoverExclusionRules {
 
     object CommonFeature : FeatureModule {
         override val classes: List<String>
-            get() = commonClasses + listOf(
-                "eu.europa.ec.commonfeature.ui.document_details.DetailsContent*",
-            )
+            get() = commonClasses
 
         override val packages: List<String>
-            get() = commonPackages + listOf(
-                "eu.europa.ec.commonfeature.config",
-                "eu.europa.ec.commonfeature.ui.*.model",
-            )
+            get() = commonPackages
     }
 
     object StartupFeature : FeatureModule {
@@ -147,9 +136,7 @@ sealed interface KoverExclusionRules {
             get() = commonClasses
 
         override val packages: List<String>
-            get() = commonPackages + listOf(
-                "eu.europa.ec.dashboardfeature.ui.scanner.component",
-            )
+            get() = commonPackages
     }
 
     object PresentationFeature : FeatureModule {
@@ -165,9 +152,7 @@ sealed interface KoverExclusionRules {
             get() = commonClasses
 
         override val packages: List<String>
-            get() = commonPackages + listOf(
-                "eu.europa.ec.proximityfeature.ui.qr.component",
-            )
+            get() = commonPackages
     }
 
     object IssuanceFeature : FeatureModule {

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/extension/DomainClaimExtensions.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/extension/DomainClaimExtensions.kt
@@ -1,4 +1,4 @@
-package eu.europa.ec.commonfeature.extensions
+package eu.europa.ec.commonfeature.extension
 
 import eu.europa.ec.commonfeature.ui.request.model.DocumentPayloadDomain
 import eu.europa.ec.commonfeature.util.keyIsPortrait

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/document_details/transformer/DocumentDetailsTransformer.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/document_details/transformer/DocumentDetailsTransformer.kt
@@ -18,7 +18,7 @@ package eu.europa.ec.commonfeature.ui.document_details.transformer
 
 import eu.europa.ec.businesslogic.provider.UuidProvider
 import eu.europa.ec.businesslogic.util.formatInstant
-import eu.europa.ec.commonfeature.extensions.toExpandableListItems
+import eu.europa.ec.commonfeature.extension.toExpandableListItems
 import eu.europa.ec.commonfeature.model.DocumentDetailsUi
 import eu.europa.ec.commonfeature.model.DocumentUiIssuanceState
 import eu.europa.ec.commonfeature.ui.document_details.domain.DocumentDetailsDomain

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
@@ -17,7 +17,7 @@
 package eu.europa.ec.commonfeature.ui.request.transformer
 
 import eu.europa.ec.businesslogic.provider.UuidProvider
-import eu.europa.ec.commonfeature.extensions.toSelectiveExpandableListItems
+import eu.europa.ec.commonfeature.extension.toSelectiveExpandableListItems
 import eu.europa.ec.commonfeature.ui.request.model.DocumentPayloadDomain
 import eu.europa.ec.commonfeature.ui.request.model.DomainDocumentFormat
 import eu.europa.ec.commonfeature.ui.request.model.RequestDocumentItemUi

--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/TransactionDetailsInteractor.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/TransactionDetailsInteractor.kt
@@ -20,7 +20,7 @@ import eu.europa.ec.businesslogic.extension.safeAsync
 import eu.europa.ec.businesslogic.provider.UuidProvider
 import eu.europa.ec.businesslogic.util.FULL_DATETIME_PATTERN
 import eu.europa.ec.businesslogic.util.formatLocalDateTime
-import eu.europa.ec.commonfeature.extensions.toExpandableListItems
+import eu.europa.ec.commonfeature.extension.toExpandableListItems
 import eu.europa.ec.commonfeature.model.TransactionUiStatus
 import eu.europa.ec.commonfeature.model.TransactionUiStatus.Companion.toUiText
 import eu.europa.ec.commonfeature.model.toTransactionUiStatus

--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/DocumentIssuanceSuccessInteractor.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/DocumentIssuanceSuccessInteractor.kt
@@ -18,7 +18,7 @@ package eu.europa.ec.issuancefeature.interactor
 
 import eu.europa.ec.businesslogic.extension.safeAsync
 import eu.europa.ec.businesslogic.provider.UuidProvider
-import eu.europa.ec.commonfeature.extensions.toExpandableListItems
+import eu.europa.ec.commonfeature.extension.toExpandableListItems
 import eu.europa.ec.commonfeature.util.transformPathsToDomainClaims
 import eu.europa.ec.corelogic.controller.WalletCoreDocumentsController
 import eu.europa.ec.corelogic.extension.localizedIssuerMetadata

--- a/presentation-feature/src/main/java/eu/europa/ec/presentationfeature/interactor/PresentationSuccessInteractor.kt
+++ b/presentation-feature/src/main/java/eu/europa/ec/presentationfeature/interactor/PresentationSuccessInteractor.kt
@@ -19,7 +19,7 @@ package eu.europa.ec.presentationfeature.interactor
 import eu.europa.ec.businesslogic.extension.ifEmptyOrNull
 import eu.europa.ec.businesslogic.extension.safeAsync
 import eu.europa.ec.businesslogic.provider.UuidProvider
-import eu.europa.ec.commonfeature.extensions.toExpandableListItems
+import eu.europa.ec.commonfeature.extension.toExpandableListItems
 import eu.europa.ec.commonfeature.util.transformPathsToDomainClaims
 import eu.europa.ec.corelogic.controller.WalletCoreDocumentsController
 import eu.europa.ec.corelogic.controller.WalletCorePresentationController

--- a/proximity-feature/src/main/java/eu/europa/ec/proximityfeature/interactor/ProximitySuccessInteractor.kt
+++ b/proximity-feature/src/main/java/eu/europa/ec/proximityfeature/interactor/ProximitySuccessInteractor.kt
@@ -19,7 +19,7 @@ package eu.europa.ec.proximityfeature.interactor
 import eu.europa.ec.businesslogic.extension.ifEmptyOrNull
 import eu.europa.ec.businesslogic.extension.safeAsync
 import eu.europa.ec.businesslogic.provider.UuidProvider
-import eu.europa.ec.commonfeature.extensions.toExpandableListItems
+import eu.europa.ec.commonfeature.extension.toExpandableListItems
 import eu.europa.ec.commonfeature.util.transformPathsToDomainClaims
 import eu.europa.ec.corelogic.controller.WalletCoreDocumentsController
 import eu.europa.ec.corelogic.controller.WalletCorePresentationController


### PR DESCRIPTION
…clusion rules

- Renamed the `extensions` package in `common-feature` to `extension` for consistency.
- Updated import paths in various files to reflect the package name change:
    - `DocumentDetailsTransformer.kt`
    - `RequestTransformer.kt`
    - `TransactionDetailsInteractor.kt`
    - `PresentationSuccessInteractor.kt`
    - `ProximitySuccessInteractor.kt`
    - `DocumentIssuanceSuccessInteractor.kt`
- Modified Kover exclusion rules in `KoverExclusionRules.kt`:
    - Added new common exclusion rules for packages: `DOMAIN_MODELS`, `EXTENSIONS`, `CONFIGS`, `TRANSFORMERS`, `UTILS`, `COMPONENTS`, `PROVIDERS`.
    - Removed specific class and package exclusions from `BusinessLogic`, `UiLogic`, `CommonFeature`, `DashboardFeature`, `ProximityFeature` as they are now covered by the common rules.
    - Updated `UiLogic` to exclude `eu.europa.ec.uilogic.navigation` and `eu.europa.ec.uilogic.serializer` packages.
- Adjusted Kover configuration in `KoverAndroid.kt` by removing explicit `extensions` receiver type.
- Updated comments in `assembly-logic/build.gradle.kts` for clarity regarding Kover reports.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable