### PR TITLE
Refactor: Enhance PIN storage security with encryption

### DIFF
--- a/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/controller/authentication/BiometricAuthenticationController.kt
+++ b/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/controller/authentication/BiometricAuthenticationController.kt
@@ -194,7 +194,7 @@ class BiometricAuthenticationControllerImpl(
     private suspend fun retrieveCrypto(): Pair<BiometricAuthentication?, Cipher?> =
         withContext(dispatcher) {
             val biometricData = biometryStorageController.getBiometricAuthentication()
-            val cipher = cryptoController.getBiometricCipher(
+            val cipher = cryptoController.getCipher(
                 encrypt = biometricData == null,
                 ivBytes = biometricData?.ivString?.decodeFromPemBase64String() ?: ByteArray(0)
             )
@@ -212,7 +212,7 @@ class BiometricAuthenticationControllerImpl(
                 biometryStorageController.setBiometricAuthentication(
                     BiometricAuthentication(
                         randomString = randomString,
-                        encryptedString = cryptoController.encryptDecryptBiometric(
+                        encryptedString = cryptoController.encryptDecrypt(
                             cipher = it,
                             byteArray = randomString.toByteArray(StandardCharsets.UTF_8)
                         ).encodeToPemBase64String().orEmpty(),
@@ -224,7 +224,7 @@ class BiometricAuthenticationControllerImpl(
                 if (biometricAuthentication.randomString
                         .toByteArray(StandardCharsets.UTF_8)
                         .contentEquals(
-                            cryptoController.encryptDecryptBiometric(
+                            cryptoController.encryptDecrypt(
                                 cipher = it,
                                 byteArray = biometricAuthentication.encryptedString
                                     .decodeFromPemBase64String() ?: ByteArray(0)

--- a/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/di/LogicAuthenticationModule.kt
+++ b/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/di/LogicAuthenticationModule.kt
@@ -42,9 +42,10 @@ class LogicAuthenticationModule
 
 @Single
 fun provideStorageConfig(
-    prefsController: PrefsController
+    prefsController: PrefsController,
+    cryptoController: CryptoController
 ): StorageConfig = StorageConfigImpl(
-    pinImpl = PrefsPinStorageProvider(prefsController),
+    pinImpl = PrefsPinStorageProvider(prefsController, cryptoController),
     biometryImpl = PrefsBiometryStorageProvider(prefsController)
 )
 

--- a/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/storage/PrefsBiometryStorageProvider.kt
+++ b/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/storage/PrefsBiometryStorageProvider.kt
@@ -34,7 +34,7 @@ class PrefsBiometryStorageProvider(
                 prefsController.getString("BiometricAuthentication", ""),
                 BiometricAuthentication::class.java
             )
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             null
         }
     }

--- a/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/storage/PrefsPinStorageProvider.kt
+++ b/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/storage/PrefsPinStorageProvider.kt
@@ -82,18 +82,15 @@ class PrefsPinStorageProvider(
             "PinIv", ""
         ).ifEmpty { return "" }
 
-        val encryptedBytes = decodeFromBase64(encryptedBase64)
-        val ivBytes = decodeFromBase64(ivBase64)
-
         val cipher = cryptoController.getCipher(
             encrypt = false,
-            ivBytes = ivBytes,
+            ivBytes = decodeFromBase64(ivBase64),
             userAuthenticationRequired = false
         )
 
         val decryptedBytes = cryptoController.encryptDecrypt(
             cipher = cipher,
-            byteArray = encryptedBytes
+            byteArray = decodeFromBase64(encryptedBase64)
         )
 
         return decryptedBytes.toString(Charsets.UTF_8)

--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/crypto/CryptoController.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/crypto/CryptoController.kt
@@ -24,23 +24,58 @@ import javax.crypto.spec.GCMParameterSpec
 typealias GUID = String
 
 interface CryptoController {
-    fun generateCodeVerifier(): String
 
     /**
-     * Returns the [Cipher] needed to create the [androidx.biometric.BiometricPrompt.CryptoObject]
-     * for biometric authentication.
-     * [encrypt] should be set to true if the cipher should encrypt, false otherwise.
-     * [ivBytes] is needed only for decryption to create the [GCMParameterSpec].
+     * Generates a code verifier for Proof Key for Code Exchange (PKCE).
+     *
+     * This function generates a cryptographically random string that is used as the code
+     * verifier in the PKCE flow. The code verifier is a high-entropy string that is
+     * difficult to guess. It is used to protect against authorization code interception attacks.
+     *
+     * The generated code verifier is a Base64 URL-safe encoded string without padding or wrapping.
+     *
+     * @return A [String] representing the generated code verifier.
      */
-    fun getBiometricCipher(encrypt: Boolean = false, ivBytes: ByteArray? = null): Cipher?
+    fun generateCodeVerifier(): String
+
+
+    /**
+     * Retrieves a [Cipher] instance configured for either encryption or decryption.
+     *
+     * This function initializes a [Cipher] object using the AES/GCM/NoPadding transformation.
+     * The behavior of the cipher (encryption or decryption) is determined by the [encrypt] parameter.
+     *
+     * - If [encrypt] is `true`, the cipher is initialized in `Cipher.ENCRYPT_MODE`.
+     * - If [encrypt] is `false`, the cipher is initialized in `Cipher.DECRYPT_MODE`, and the
+     *   [ivBytes] parameter is required to provide the Initialization Vector (IV) for the
+     *   GCMParameterSpec.
+     *
+     * The secret key used for cipher initialization is retrieved or generated via the
+     * `keystoreController`.
+     *
+     * @param encrypt A [Boolean] indicating whether the cipher should be initialized for
+     * encryption (`true`) or decryption (`false`). Defaults to `false`.
+     * @param ivBytes An optional [ByteArray] containing the Initialization Vector. This is
+     * required only when `encrypt` is `false` (i.e., for decryption).
+     * @param userAuthenticationRequired A [Boolean] indicating if user authentication is
+     * required for the cryptographic operation. Defaults to `true`.
+     * @return A configured [Cipher] instance if initialization is successful, or `null` if an
+     * exception occurs during initialization.
+     */
+    fun getCipher(
+        encrypt: Boolean = false,
+        ivBytes: ByteArray? = null,
+        userAuthenticationRequired: Boolean = true
+    ): Cipher?
+
 
     /**
      * Returns the [ByteArray] after the encryption/decryption from the given [Cipher].
-     * [cipher] the biometric cipher needed. This can be null but then an empty [ByteArray] is
+     * [cipher] the cipher needed. This can be null but then an empty [ByteArray] is
      * returned.
      * [byteArray] that needed to be encrypted or decrypted (Depending always on [Cipher] provided.
      */
-    fun encryptDecryptBiometric(cipher: Cipher?, byteArray: ByteArray): ByteArray
+    fun encryptDecrypt(cipher: Cipher?, byteArray: ByteArray): ByteArray
 }
 
 class CryptoControllerImpl(
@@ -61,28 +96,32 @@ class CryptoControllerImpl(
         return Base64.encodeToString(code, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
     }
 
-    override fun getBiometricCipher(encrypt: Boolean, ivBytes: ByteArray?): Cipher? =
+    override fun getCipher(
+        encrypt: Boolean,
+        ivBytes: ByteArray?,
+        userAuthenticationRequired: Boolean
+    ): Cipher? =
         try {
             Cipher.getInstance(AES_EXTERNAL_TRANSFORMATION).apply {
                 if (encrypt) {
                     init(
                         Cipher.ENCRYPT_MODE,
-                        keystoreController.retrieveOrGenerateBiometricSecretKey()
+                        keystoreController.retrieveOrGenerateSecretKey(userAuthenticationRequired)
                     )
                 } else {
                     init(
                         Cipher.DECRYPT_MODE,
-                        keystoreController.retrieveOrGenerateBiometricSecretKey(),
+                        keystoreController.retrieveOrGenerateSecretKey(userAuthenticationRequired),
                         GCMParameterSpec(IV_SIZE, ivBytes)
                     )
                 }
             }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             null
         }
 
 
-    override fun encryptDecryptBiometric(cipher: Cipher?, byteArray: ByteArray): ByteArray {
+    override fun encryptDecrypt(cipher: Cipher?, byteArray: ByteArray): ByteArray {
         return cipher?.doFinal(byteArray) ?: ByteArray(0)
     }
 }

--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/crypto/KeystoreController.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/crypto/KeystoreController.kt
@@ -27,7 +27,7 @@ import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 
 interface KeystoreController {
-    fun retrieveOrGenerateBiometricSecretKey(): SecretKey?
+    fun retrieveOrGenerateSecretKey(userAuthenticationRequired: Boolean): SecretKey?
 }
 
 class KeystoreControllerImpl(
@@ -46,9 +46,6 @@ class KeystoreControllerImpl(
         loadKeyStore()
     }
 
-    /**
-     * Load/Init KeyStore
-     */
     private fun loadKeyStore() {
         try {
             androidKeyStore = KeyStore.getInstance(STORE_TYPE)
@@ -59,42 +56,58 @@ class KeystoreControllerImpl(
     }
 
     /**
-     * Retrieves the existing biometric secret key if exists or generates a new one if it is the
-     * first time.
+     * Retrieves an existing secret key or generates a new one.
+     *
+     * If an alias for a secret key is found in preferences, this function attempts to retrieve the key
+     * associated with that alias from the Android KeyStore.
+     *
+     * If no alias is found or if the key retrieval fails, a new secret key is generated.
+     * The new key is then stored in the Android KeyStore under a newly generated alias,
+     * and this new alias is saved in preferences for future use.
+     *
+     * The generation of the new key can be configured to require user authentication.
+     *
+     * @param userAuthenticationRequired A boolean indicating whether the newly generated key
+     *                                   should require user authentication for its use.
+     * @return The retrieved or newly generated [SecretKey], or `null` if the Android KeyStore
+     *         is unavailable or if any other error occurs during the process.
      */
-    override fun retrieveOrGenerateBiometricSecretKey(): SecretKey? {
+    override fun retrieveOrGenerateSecretKey(userAuthenticationRequired: Boolean): SecretKey? {
         return androidKeyStore?.let {
-            val alias = prefKeys.getBiometricAlias()
+            val alias = prefKeys.getCryptoAlias()
             if (alias.isEmpty()) {
                 val newAlias = createPublicKey()
-                generateBiometricSecretKey(newAlias)
-                prefKeys.setBiometricAlias(newAlias)
-                getBiometricSecretKey(it, newAlias)
+                generateSecretKey(newAlias, userAuthenticationRequired)
+                prefKeys.setCryptoAlias(newAlias)
+                getSecretKey(it, newAlias)
             } else {
-                getBiometricSecretKey(it, alias)
+                getSecretKey(it, alias)
             }
         }
     }
 
     @Suppress("DEPRECATION")
-    private fun generateBiometricSecretKey(alias: String) {
+    private fun generateSecretKey(alias: String, userAuthenticationRequired: Boolean) {
         val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, STORE_TYPE)
 
         val builder = KeyGenParameterSpec.Builder(
             alias,
             KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
         ).apply {
+            setKeySize(256)
             setBlockModes(KeyProperties.BLOCK_MODE_GCM)
             setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-            setUserAuthenticationRequired(true)
-            setInvalidatedByBiometricEnrollment(true)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                setUserAuthenticationParameters(
-                    0,
-                    KeyProperties.AUTH_DEVICE_CREDENTIAL or KeyProperties.AUTH_BIOMETRIC_STRONG
-                )
-            } else {
-                setUserAuthenticationValidityDurationSeconds(-1)
+            if (userAuthenticationRequired) {
+                setUserAuthenticationRequired(true)
+                setInvalidatedByBiometricEnrollment(true)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    setUserAuthenticationParameters(
+                        0,
+                        KeyProperties.AUTH_DEVICE_CREDENTIAL or KeyProperties.AUTH_BIOMETRIC_STRONG
+                    )
+                } else {
+                    setUserAuthenticationValidityDurationSeconds(-1)
+                }
             }
         }
 
@@ -105,7 +118,7 @@ class KeystoreControllerImpl(
         keyGenerator.generateKey()
     }
 
-    private fun getBiometricSecretKey(keyStore: KeyStore, alias: String): SecretKey {
+    private fun getSecretKey(keyStore: KeyStore, alias: String): SecretKey {
         keyStore.load(null)
         return keyStore.getKey(alias, null) as SecretKey
     }

--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/storage/PrefsController.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/storage/PrefsController.kt
@@ -307,8 +307,8 @@ class PrefsControllerImpl(
 }
 
 interface PrefKeys {
-    fun getBiometricAlias(): String
-    fun setBiometricAlias(value: String)
+    fun getCryptoAlias(): String
+    fun setCryptoAlias(value: String)
 
     fun getShowBatchIssuanceCounter(): Boolean
     fun setShowBatchIssuanceCounter(value: Boolean)
@@ -318,20 +318,28 @@ class PrefKeysImpl(
     private val prefsController: PrefsController
 ) : PrefKeys {
 
-    /**
-     * Returns the biometric alias in order to find the biometric secret key in android keystore.
-     */
-    override fun getBiometricAlias(): String {
-        return prefsController.getString("BiometricAlias", "")
-    }
 
     /**
-     * Stores the biometric alias used for the secret key in android keystore.
+     * Retrieves the alias used for cryptographic operations from SharedPreferences.
+     * This alias is typically used to identify a specific key or set of keys
+     * stored in the Android Keystore system.
      *
-     * @param value the biometric alias value.
+     * @return The crypto alias string. Returns an empty string if the alias is not found
+     *         or has not been set.
      */
-    override fun setBiometricAlias(value: String) {
-        prefsController.setString("BiometricAlias", value)
+    override fun getCryptoAlias(): String {
+        return prefsController.getString("CryptoAlias", "")
+    }
+
+
+    /**
+     * Stores the crypto alias used for the secret key in android keystore.
+     * This is used for cryptographic operations not related to biometrics.
+     *
+     * @param value the crypto alias value.
+     */
+    override fun setCryptoAlias(value: String) {
+        prefsController.setString("CryptoAlias", value)
     }
 
     /**

--- a/wiki/configuration.md
+++ b/wiki/configuration.md
@@ -411,15 +411,14 @@ The project utilizes Koin for Dependency Injection (DI), thus requiring adjustme
 Implementation Example:
 ```Kotlin
 class PrefsPinStorageProvider(
-    private val prefsController: PrefsController
+    private val prefsController: PrefsController,
+    private val cryptoController: CryptoController
 ) : PinStorageProvider {
 
-    override fun retrievePin(): String {
-        return prefsController.getString("DevicePin", "")
-    }
+    override fun retrievePin(): String = decryptedAndLoad()
 
     override fun setPin(pin: String) {
-        prefsController.setString("DevicePin", pin)
+       encryptAndStore(pin)
     }
 
     override fun isPinValid(pin: String): Boolean = retrievePin() == pin
@@ -443,9 +442,10 @@ Config Construction via Koin DI Example:
 ```Kotlin
 @Single
 fun provideStorageConfig(
-    prefsController: PrefsController
+    prefsController: PrefsController,
+    cryptoController: CryptoController
 ): StorageConfig = StorageConfigImpl(
-    pinImpl = PrefsPinStorageProvider(prefsController),
+    pinImpl = PrefsPinStorageProvider(prefsController, cryptoController),
     biometryImpl = PrefsBiometryStorageProvider(prefsController)
 )
 ```


### PR DESCRIPTION
This commit introduces encryption for PIN storage within the `PrefsPinStorageProvider`.

Key changes:
- PINs are now encrypted using AES/GCM/NoPadding before being stored in SharedPreferences.
- The `CryptoController` is utilized for encryption and decryption operations.
- `KeystoreController` now manages a general-purpose secret key for cryptographic operations, replacing the biometric-specific key.
- Relevant methods in `CryptoController` and `KeystoreController` have been updated to reflect this change (e.g., `getBiometricCipher` to `getCipher`, `retrieveOrGenerateBiometricSecretKey` to `retrieveOrGenerateSecretKey`).
- The `PrefKeys` interface and its implementation have been updated to use `CryptoAlias` instead of `BiometricAlias`.
- Dependency injection for `PrefsPinStorageProvider` now includes `CryptoController`.
- Documentation in `configuration.md` has been updated to reflect the new `PrefsPinStorageProvider` constructor.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable