### PR TITLE
ProGuard: Ignore okhttp3.internal.Util warnings

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -91,6 +91,7 @@
 -dontwarn org.koin.androidx.viewmodel.GetViewModelKt
 -dontwarn org.koin.compose.stable.StableHoldersKt
 -dontwarn org.koin.compose.stable.StableParametersDefinition
+-dontwarn okhttp3.internal.Util
 
 # Retrofit
 -keep,allowobfuscation,allowshrinking interface retrofit2.Call


### PR DESCRIPTION
This commit adds `okhttp3.internal.Util` to the ProGuard rules to suppress warnings.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable