### PR TITLE
Refactor: Remove WrapModalBottomSheet from HomeScreenSheetContent

### DIFF
--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/home/HomeScreen.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/home/HomeScreen.kt
@@ -140,7 +140,6 @@ fun HomeScreen(
             HomeScreenSheetContent(
                 sheetContent = state.sheetContent,
                 onEventSent = { event -> viewModel.setEvent(event) },
-                modalBottomSheetState = bottomSheetState
             )
         }
     }
@@ -300,71 +299,56 @@ private fun handleNavigationEffect(
 private fun HomeScreenSheetContent(
     sheetContent: HomeScreenBottomSheetContent,
     onEventSent: (event: Event) -> Unit,
-    modalBottomSheetState: SheetState
 ) {
     when (sheetContent) {
         is HomeScreenBottomSheetContent.Authenticate -> {
-            WrapModalBottomSheet(
-                onDismissRequest = {
-                    onEventSent(Event.BottomSheet.UpdateBottomSheetState(isOpen = false))
-                },
-                sheetState = modalBottomSheetState
-            ) {
-                BottomSheetWithTwoBigIcons(
-                    textData = BottomSheetTextDataUi(
-                        title = stringResource(R.string.home_screen_authenticate),
-                        message = stringResource(R.string.home_screen_authenticate_description)
+            BottomSheetWithTwoBigIcons(
+                textData = BottomSheetTextDataUi(
+                    title = stringResource(R.string.home_screen_authenticate),
+                    message = stringResource(R.string.home_screen_authenticate_description)
+                ),
+                options = listOf(
+                    ModalOptionUi(
+                        title = stringResource(R.string.home_screen_authenticate_option_in_person),
+                        leadingIcon = AppIcons.PresentDocumentInPerson,
+                        event = Event.BottomSheet.Authenticate.OpenAuthenticateInPerson,
                     ),
-                    options = listOf(
-                        ModalOptionUi(
-                            title = stringResource(R.string.home_screen_authenticate_option_in_person),
-                            leadingIcon = AppIcons.PresentDocumentInPerson,
-                            event = Event.BottomSheet.Authenticate.OpenAuthenticateInPerson,
-                        ),
-                        ModalOptionUi(
-                            title = stringResource(R.string.home_screen_add_document_option_online),
-                            leadingIcon = AppIcons.PresentDocumentOnline,
-                            event = Event.BottomSheet.Authenticate.OpenAuthenticateOnLine,
-                        )
-                    ),
-                    onEventSent = { event ->
-                        onEventSent(event)
-                    }
-                )
-            }
+                    ModalOptionUi(
+                        title = stringResource(R.string.home_screen_add_document_option_online),
+                        leadingIcon = AppIcons.PresentDocumentOnline,
+                        event = Event.BottomSheet.Authenticate.OpenAuthenticateOnLine,
+                    )
+                ),
+                onEventSent = { event ->
+                    onEventSent(event)
+                }
+            )
         }
 
         is HomeScreenBottomSheetContent.Sign -> {
-            WrapModalBottomSheet(
-                onDismissRequest = {
-                    onEventSent(Event.BottomSheet.UpdateBottomSheetState(isOpen = false))
-                },
-                sheetState = modalBottomSheetState
-            ) {
-                BottomSheetWithTwoBigIcons(
-                    textData = BottomSheetTextDataUi(
-                        title = stringResource(R.string.home_screen_sign_document),
-                        message = stringResource(R.string.home_screen_sign_document_description)
+            BottomSheetWithTwoBigIcons(
+                textData = BottomSheetTextDataUi(
+                    title = stringResource(R.string.home_screen_sign_document),
+                    message = stringResource(R.string.home_screen_sign_document_description)
+                ),
+                options = listOf(
+                    ModalOptionUi(
+                        title = stringResource(R.string.home_screen_sign_document_option_from_device),
+                        leadingIcon = AppIcons.SignDocumentFromDevice,
+                        leadingIconTint = MaterialTheme.colorScheme.primary,
+                        event = Event.BottomSheet.SignDocument.OpenFromDevice,
                     ),
-                    options = listOf(
-                        ModalOptionUi(
-                            title = stringResource(R.string.home_screen_sign_document_option_from_device),
-                            leadingIcon = AppIcons.SignDocumentFromDevice,
-                            leadingIconTint = MaterialTheme.colorScheme.primary,
-                            event = Event.BottomSheet.SignDocument.OpenFromDevice,
-                        ),
-                        ModalOptionUi(
-                            title = stringResource(R.string.home_screen_sign_document_option_scan_qr),
-                            leadingIcon = AppIcons.SignDocumentFromQr,
-                            leadingIconTint = MaterialTheme.colorScheme.primary,
-                            event = Event.BottomSheet.SignDocument.OpenScanQR,
-                        )
-                    ),
-                    onEventSent = { event ->
-                        onEventSent(event)
-                    }
-                )
-            }
+                    ModalOptionUi(
+                        title = stringResource(R.string.home_screen_sign_document_option_scan_qr),
+                        leadingIcon = AppIcons.SignDocumentFromQr,
+                        leadingIconTint = MaterialTheme.colorScheme.primary,
+                        event = Event.BottomSheet.SignDocument.OpenScanQR,
+                    )
+                ),
+                onEventSent = { event ->
+                    onEventSent(event)
+                }
+            )
         }
 
         is HomeScreenBottomSheetContent.LearnMoreAboutAuthenticate -> {


### PR DESCRIPTION
The `WrapModalBottomSheet` component was removed from `HomeScreenSheetContent` as it was redundant. The `ModalBottomSheetLayout` in the parent `HomeScreen` already handles the modal behavior.

This change simplifies the `HomeScreenSheetContent` by removing the unnecessary wrapper and passing the `SheetState` directly from the parent.

# Description of changes
Add a description of the change here

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable