### PR TITLE
Remove background color for animated card in DocumentDetailsScreen

### DIFF
--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/detail/DocumentDetailsScreen.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/detail/DocumentDetailsScreen.kt
@@ -500,10 +500,7 @@ private fun ExpandedDocumentCredentials(
                     enter = fadeIn(),
                     exit = fadeOut(),
                     resizeMode = SharedTransitionScope.ResizeMode.RemeasureToBounds,
-                ),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceDim,
-            )
+                )
         ) {
             Column(
                 modifier = Modifier


### PR DESCRIPTION
# Description of changes
The background color of the animated card in the `DocumentDetailsScreen` has been removed. The card now uses the default container color.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable