### PR TITLE
add toggle to disable verifier certificate checks

### DIFF
--- a/core-logic/src/demo/java/eu/europa/ec/corelogic/config/WalletCoreConfigImpl.kt
+++ b/core-logic/src/demo/java/eu/europa/ec/corelogic/config/WalletCoreConfigImpl.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.corelogic.config
 
 import android.content.Context
 import eu.europa.ec.corelogic.BuildConfig
+import eu.europa.ec.corelogic.extension.getCertificateCheckState
 import eu.europa.ec.eudi.wallet.EudiWalletConfig
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.ClientIdScheme
@@ -79,17 +80,19 @@ internal class WalletCoreConfigImpl(
                         withUseDPoPIfSupported(true)
                     }
 
-                    configureReaderTrustStore(
-                        context,
-                        R.raw.pidissuerca02_cz,
-                        R.raw.pidissuerca02_ee,
-                        R.raw.pidissuerca02_eu,
-                        R.raw.pidissuerca02_lu,
-                        R.raw.pidissuerca02_nl,
-                        R.raw.pidissuerca02_pt,
-                        R.raw.pidissuerca02_ut,
-                        R.raw.dc4eu
-                    )
+                    if (context.getCertificateCheckState()) {
+                        configureReaderTrustStore(
+                            context,
+                            R.raw.pidissuerca02_cz,
+                            R.raw.pidissuerca02_ee,
+                            R.raw.pidissuerca02_eu,
+                            R.raw.pidissuerca02_lu,
+                            R.raw.pidissuerca02_nl,
+                            R.raw.pidissuerca02_pt,
+                            R.raw.pidissuerca02_ut,
+                            R.raw.dc4eu
+                        )
+                    }
                 }
             }
             return _config!!

--- a/core-logic/src/dev/java/eu/europa/ec/corelogic/config/WalletCoreConfigImpl.kt
+++ b/core-logic/src/dev/java/eu/europa/ec/corelogic/config/WalletCoreConfigImpl.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.corelogic.config
 
 import android.content.Context
 import eu.europa.ec.corelogic.BuildConfig
+import eu.europa.ec.corelogic.extension.getCertificateCheckState
 import eu.europa.ec.eudi.wallet.EudiWalletConfig
 import eu.europa.ec.eudi.wallet.issue.openid4vci.OpenId4VciManager
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.ClientIdScheme
@@ -79,17 +80,19 @@ internal class WalletCoreConfigImpl(
                         withUseDPoPIfSupported(true)
                     }
 
-                    configureReaderTrustStore(
-                        context,
-                        R.raw.pidissuerca02_cz,
-                        R.raw.pidissuerca02_ee,
-                        R.raw.pidissuerca02_eu,
-                        R.raw.pidissuerca02_lu,
-                        R.raw.pidissuerca02_nl,
-                        R.raw.pidissuerca02_pt,
-                        R.raw.pidissuerca02_ut,
-                        R.raw.dc4eu
-                    )
+                    if (context.getCertificateCheckState()) {
+                        configureReaderTrustStore(
+                            context,
+                            R.raw.pidissuerca02_cz,
+                            R.raw.pidissuerca02_ee,
+                            R.raw.pidissuerca02_eu,
+                            R.raw.pidissuerca02_lu,
+                            R.raw.pidissuerca02_nl,
+                            R.raw.pidissuerca02_pt,
+                            R.raw.pidissuerca02_ut,
+                            R.raw.dc4eu
+                        )
+                    }
                 }
             }
             return _config!!

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/extension/ContextExtensions.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/extension/ContextExtensions.kt
@@ -14,17 +14,23 @@
  * governing permissions and limitations under the Licence.
  */
 
-package eu.europa.ec.dashboardfeature.ui.dashboard.model
+package eu.europa.ec.corelogic.extension
 
-import eu.europa.ec.uilogic.component.ListItemDataUi
+import android.content.Context
+import androidx.core.content.edit
 
-data class SideMenuItemUi(
-    val type: SideMenuTypeUi,
-    val data: ListItemDataUi,
-)
+fun Context.getCertificateCheckState(): Boolean {
+    return this.getSharedPreferences(
+        "CertificatePrefs",
+        Context.MODE_PRIVATE
+    ).getBoolean("certificate_check_enabled", true)
+}
 
-enum class SideMenuTypeUi {
-    CHANGE_PIN,
-    SETTINGS,
-    ENABLE_CERTIFICATE
+fun Context.updateCertificateCheck(newState: Boolean) {
+    this.getSharedPreferences(
+        "CertificatePrefs",
+        Context.MODE_PRIVATE
+    ).edit {
+        putBoolean("certificate_check_enabled", newState)
+    }
 }

--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/DashboardInteractor.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/DashboardInteractor.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.dashboardfeature.interactor
 
+import eu.europa.ec.corelogic.extension.getCertificateCheckState
 import eu.europa.ec.dashboardfeature.ui.dashboard.model.SideMenuItemUi
 import eu.europa.ec.dashboardfeature.ui.dashboard.model.SideMenuTypeUi
 import eu.europa.ec.resourceslogic.R
@@ -25,6 +26,7 @@ import eu.europa.ec.uilogic.component.ListItemDataUi
 import eu.europa.ec.uilogic.component.ListItemLeadingContentDataUi
 import eu.europa.ec.uilogic.component.ListItemMainContentDataUi
 import eu.europa.ec.uilogic.component.ListItemTrailingContentDataUi
+import eu.europa.ec.uilogic.component.wrap.CheckboxDataUi
 
 interface DashboardInteractor {
     fun getSideMenuOptions(): List<SideMenuItemUi>
@@ -71,6 +73,28 @@ class DashboardInteractorImpl(
                     )
                 )
             )
+
+            add(
+                SideMenuItemUi(
+                    type = SideMenuTypeUi.ENABLE_CERTIFICATE,
+                    data = ListItemDataUi(
+                        itemId = resourceProvider.getString(R.string.dashboard_side_menu_enable_certificates_id),
+                        mainContentData = ListItemMainContentDataUi.Text(
+                            text = resourceProvider.getString(R.string.dashboard_side_menu_enable_certificates)
+                        ),
+                        supportingText = resourceProvider.getString(R.string.dashboard_side_menu_enable_certificates_description),
+                        leadingContentData = ListItemLeadingContentDataUi.Icon(
+                            iconData = AppIcons.Certified
+                        ),
+                        trailingContentData = ListItemTrailingContentDataUi.Checkbox(
+                            checkboxData = CheckboxDataUi(
+                                isChecked = resourceProvider.provideContext().getCertificateCheckState(),
+                            )
+                        )
+                    )
+                )
+            )
+
         }
     }
 }

--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/dashboard/DashboardViewModel.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/dashboard/DashboardViewModel.kt
@@ -24,6 +24,8 @@ import eu.europa.ec.commonfeature.config.PresentationMode
 import eu.europa.ec.commonfeature.config.RequestUriConfig
 import eu.europa.ec.commonfeature.model.PinFlow
 import eu.europa.ec.corelogic.di.getOrCreatePresentationScope
+import eu.europa.ec.corelogic.extension.getCertificateCheckState
+import eu.europa.ec.corelogic.extension.updateCertificateCheck
 import eu.europa.ec.corelogic.model.RevokedDocumentDataDomain
 import eu.europa.ec.dashboardfeature.interactor.DashboardInteractor
 import eu.europa.ec.dashboardfeature.ui.dashboard.model.SideMenuItemUi
@@ -256,6 +258,18 @@ class DashboardViewModel(
             SideMenuTypeUi.SETTINGS -> {
                 hideSideMenu()
                 setEffect { Effect.Navigation.SwitchScreen(screenRoute = DashboardScreens.Settings.screenRoute) }
+
+            }
+
+            SideMenuTypeUi.ENABLE_CERTIFICATE -> {
+                val currentState = resourceProvider.provideContext().getCertificateCheckState()
+                resourceProvider.provideContext().updateCertificateCheck(!currentState)
+                setState {
+                    copy(
+                        sideMenuOptions = dashboardInteractor.getSideMenuOptions()
+                    )
+                }
+
             }
         }
     }

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestDashboardInteractor.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestDashboardInteractor.kt
@@ -16,6 +16,8 @@
 
 package eu.europa.ec.dashboardfeature.interactor
 
+import android.content.Context
+import android.content.SharedPreferences
 import eu.europa.ec.dashboardfeature.ui.dashboard.model.SideMenuTypeUi
 import eu.europa.ec.resourceslogic.R
 import eu.europa.ec.resourceslogic.provider.ResourceProvider
@@ -29,9 +31,12 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class TestDashboardInteractor {
 
@@ -58,15 +63,16 @@ class TestDashboardInteractor {
 
     //region getSideMenuOptions
     @Test
-    fun `When getSideMenuOptions is called, Then it returns two items with correct data`() {
+    fun `When getSideMenuOptions is called, Then it returns three items with correct data`() {
         // Arrange
         mockStringsNeededForGetSideMenuOptions(resourceProvider)
+        mockCertificatePreference(resourceProvider)
 
         // When
         val sideMenuItems = interactor.getSideMenuOptions()
 
         // Then
-        assertEquals(2, sideMenuItems.size)
+        assertEquals(3, sideMenuItems.size)
 
         // 1. First item: CHANGE_PIN
         val firstItem = sideMenuItems[0]
@@ -91,6 +97,15 @@ class TestDashboardInteractor {
             secondItem.data.trailingContentData as ListItemTrailingContentDataUi.Icon
         assertEquals(AppIcons.KeyboardArrowRight, trailingIcon2.iconData)
 
+        // 3. Third item: ENABLE CERTIFICATE
+        val thirdItem = sideMenuItems[2]
+        assertEquals(SideMenuTypeUi.ENABLE_CERTIFICATE, thirdItem.type)
+        assertEquals(certificateIdString, thirdItem.data.itemId)
+        val mainContent3 = thirdItem.data.mainContentData as ListItemMainContentDataUi.Text
+        assertEquals(certificateText, mainContent3.text)
+        val leadingIcon3 = thirdItem.data.leadingContentData as ListItemLeadingContentDataUi.Icon
+        assertEquals(AppIcons.Certified, leadingIcon3.iconData)
+
         // Verify that getString was called exactly once per resource ID
         verify(resourceProvider, times(1))
             .getString(R.string.dashboard_side_menu_option_change_pin_id)
@@ -100,6 +115,10 @@ class TestDashboardInteractor {
             .getString(R.string.dashboard_side_menu_option_settings_id)
         verify(resourceProvider, times(1))
             .getString(R.string.dashboard_side_menu_option_settings)
+        verify(resourceProvider, times(1))
+            .getString(R.string.dashboard_side_menu_enable_certificates_id)
+        verify(resourceProvider, times(1))
+            .getString(R.string.dashboard_side_menu_enable_certificates)
     }
     //endregion
 
@@ -112,8 +131,19 @@ class TestDashboardInteractor {
                 R.string.dashboard_side_menu_option_change_pin to changePinText,
                 R.string.dashboard_side_menu_option_settings_id to settingsIdString,
                 R.string.dashboard_side_menu_option_settings to settingsText,
+                R.string.dashboard_side_menu_enable_certificates to certificateText,
+                R.string.dashboard_side_menu_enable_certificates_id to certificateIdString
             )
         )
+    }
+
+    private fun mockCertificatePreference(resourceProvider: ResourceProvider) {
+        val mockContext: Context = mock()
+        val mockPrefs: SharedPreferences = mock()
+
+        whenever(resourceProvider.provideContext()).thenReturn(mockContext)
+        whenever(mockContext.getSharedPreferences(any(), any())).thenReturn(mockPrefs)
+        whenever(mockPrefs.getBoolean(any(), any())).thenReturn(true)
     }
     //endregion
 
@@ -122,5 +152,7 @@ class TestDashboardInteractor {
     private val changePinText = "Change PIN"
     private val settingsIdString = "settingsId"
     private val settingsText = "Settings"
+    private val certificateIdString = "enableCertificatesId"
+    private val certificateText = "Enable certificate check"
     //endregion
 }

--- a/resources-logic/src/main/res/values/strings.xml
+++ b/resources-logic/src/main/res/values/strings.xml
@@ -225,6 +225,9 @@
     <string name="settings_screen_option_changelog">Changelog</string>
     <string name="settings_screen_option_changelog_id">changelogId</string>
     <string name="settings_intent_chooser_logs_share_title">Share logs</string>
+    <string name="dashboard_side_menu_enable_certificates">Enable certificate check</string>
+    <string name="dashboard_side_menu_enable_certificates_id">enableCertificatesId</string>
+    <string name="dashboard_side_menu_enable_certificates_description">Requires a manual force restart of the application to take effect</string>
 
     <!-- Home Screen -->
     <string name="home_screen_title">Home</string>


### PR DESCRIPTION
# Description of changes
add toggle in side menu to disable verifier certificate checks

### UI:
| enabled by default | disabled check |
--|--
|<img width="1080" height="2340" alt="Screenshot_20250801_125619" src="https://github.com/user-attachments/assets/5da8219c-3e02-47d6-8a3e-f6947030cd75" />|<img width="1080" height="2340" alt="Screenshot_20250801_125628" src="https://github.com/user-attachments/assets/72546924-8042-4ba8-90b1-0a7242c09cb3" />|



## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Test suite run successfully

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable