### PR TITLE
Refactor: Adjust screen padding for sticky bottom components

### DIFF
--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/document_success/DocumentSuccessScreen.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/document_success/DocumentSuccessScreen.kt
@@ -151,7 +151,7 @@ private fun Content(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = SPACING_SMALL.dp),
+                .padding(vertical = SPACING_SMALL.dp),
             verticalArrangement = Arrangement.spacedBy(SPACING_MEDIUM.dp)
         ) {
             state.items.forEach { successItem ->

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/RequestScreen.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/RequestScreen.kt
@@ -202,7 +202,7 @@ private fun Content(
         DisplayRequestItems(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = SPACING_SMALL.dp),
+                .padding(vertical = SPACING_SMALL.dp),
             requestDocuments = state.items,
             noData = state.noItems,
             onEventSend = onEventSend,

--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/offer/DocumentOfferScreen.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/offer/DocumentOfferScreen.kt
@@ -173,7 +173,9 @@ private fun Content(
         } else {
             // Screen Main Content
             MainContent(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = SPACING_SMALL.dp),
                 documents = state.documents,
             )
         }

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/component/content/ContentScreen.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/component/content/ContentScreen.kt
@@ -143,8 +143,11 @@ fun ContentScreen(
         snackbarHost = snackbarHost,
     ) { padding ->
 
-        val screenPaddings = remember(padding) {
-            screenPaddings(padding)
+        val forcedBottomPadding = remember(padding) {
+            screenPaddings(
+                hasStickyBottom = false,
+                append = padding
+            )
         }
 
         Box(
@@ -154,13 +157,19 @@ fun ContentScreen(
             if (contentErrorConfig != null) {
                 ContentError(
                     config = contentErrorConfig,
-                    paddingValues = screenPaddings
+                    paddingValues = forcedBottomPadding
                 )
             } else {
                 Column(modifier = Modifier.fillMaxSize()) {
 
                     Box(modifier = Modifier.weight(1f)) {
-                        bodyContent(screenPaddings(padding, topSpacing))
+                        bodyContent(
+                            screenPaddings(
+                                hasStickyBottom = stickyBottom != null,
+                                append = padding,
+                                topSpacing = topSpacing
+                            )
+                        )
                     }
 
                     stickyBottom?.let { stickyBottomContent ->
@@ -172,7 +181,7 @@ fun ContentScreen(
                         ) {
                             stickyBottomContent(
                                 stickyBottomPaddings(
-                                    contentScreenPaddings = screenPaddings,
+                                    contentScreenPaddings = forcedBottomPadding,
                                     layoutDirection = LocalLayoutDirection.current
                                 )
                             )

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/component/utils/ScreenPadding.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/component/utils/ScreenPadding.kt
@@ -30,13 +30,18 @@ enum class TopSpacing {
 }
 
 internal fun screenPaddings(
+    hasStickyBottom: Boolean,
     append: PaddingValues? = null,
     topSpacing: TopSpacing = TopSpacing.WithToolbar
 ) = PaddingValues(
     start = HORIZONTAL_SCREEN_PADDING.dp,
     top = calculateTopSpacing(topSpacing).dp + (append?.calculateTopPadding() ?: 0.dp),
     end = HORIZONTAL_SCREEN_PADDING.dp,
-    bottom = BOTTOM_SCREEN_PADDING.dp + (append?.calculateBottomPadding() ?: 0.dp)
+    bottom = if (!hasStickyBottom) {
+        BOTTOM_SCREEN_PADDING.dp + (append?.calculateBottomPadding() ?: 0.dp)
+    } else {
+        0.dp
+    }
 )
 
 internal fun stickyBottomPaddings(


### PR DESCRIPTION
This commit modifies the screen padding logic to correctly handle screens with sticky bottom components.

Key changes:
- Updated `screenPaddings` function in `ScreenPadding.kt` to accept a `hasStickyBottom` parameter. If true, the bottom padding will be zero to prevent double padding when a sticky bottom component is present.
- Adjusted padding in `ContentScreen.kt` to utilize the new `hasStickyBottom` parameter in `screenPaddings`.
- Applied vertical padding (`SPACING_SMALL`) to the main content areas in `RequestScreen.kt`, `DocumentOfferScreen.kt`, and `DocumentSuccessScreen.kt` to ensure consistent spacing, especially when sticky bottom components are not pushing the content up.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable