### PR TITLE
Bump rqesUiSDK to 0.3.1 and improve APK renaming in Fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,7 @@
 # update_fastlane
 
 require "date"
+require 'fileutils'
 
 default_platform(:android)
 
@@ -114,19 +115,40 @@ platform :android do
 
   desc "Rename apk before release"
   lane :prepare_binary do |values|
-    appVersion = values[:appVersion]
-    buildType = values[:buildType]
+    app_version = values[:appVersion]
+    build_type  = values[:buildType]
 
-    defaultApkName = "app-#{buildType}-release.apk"
-    newApkName = "#{appVersion}.apk"
+    project_root = File.expand_path("..", __dir__)
+    base_dir = File.join(
+      project_root, 
+      "app", 
+      "build", 
+      "outputs", 
+      "apk", 
+      build_type, 
+      "release"
+    )
 
-    defaultApkPath = "app/build/outputs/apk/#{buildType}/release/#{defaultApkName}"
-    newApkPath = "app/build/outputs/apk/#{buildType}/release/#{newApkName}"
+    default_apk_name = "app-#{build_type}-release.apk"
+    new_apk_name = "#{app_version}.apk"
 
-    sh("cd .. && mv #{defaultApkPath} #{newApkPath}")
+    default_apk_path = File.join(base_dir, default_apk_name)
+    new_apk_path = File.join(base_dir, new_apk_name)
 
-    puts "New Apk Path For Upload: #{newApkPath}"
-    newApkPath
+    unless File.exist?(default_apk_path)
+      raise "APK not found at: #{default_apk_path}"
+    end
+
+    begin
+      FileUtils.rm_f(new_apk_path)
+      FileUtils.mv(default_apk_path, new_apk_path)
+    rescue => e
+      raise "Failed to rename APK: #{e.message}"
+    end
+
+    puts "Renamed #{default_apk_name} -> #{new_apk_name}"
+    puts "New APK Path For Upload: #{new_apk_path}"
+    new_apk_path
   end
 
   desc "Release to github"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ sonar = "6.2.0.5505"
 baselineprofile = "1.4.0"
 timber = "5.0.1"
 treessence = "1.1.2"
-rqesUiSDK = "0.3.0"
+rqesUiSDK = "0.3.1"
 androidxRoom = "2.7.2"
 cloudy = "0.2.7"
 


### PR DESCRIPTION
This commit updates the `rqesUiSDK` version to `0.3.1` in `gradle/libs.versions.toml`.

Additionally, it refactors the `prepare_binary` lane in `fastlane/Fastfile`:
- Uses `File.join` for constructing paths to improve cross-platform compatibility.
- Adds checks to ensure the original APK exists before attempting to rename.
- Implements error handling for the renaming process.
- Uses `FileUtils.mv` and `FileUtils.rm_f` for more robust file operations.
- Improves output messages for clarity.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable