### PR TITLE
Refactor: Adjust navigation bar padding

### DIFF
--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/detail/DocumentDetailsScreen.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/detail/DocumentDetailsScreen.kt
@@ -244,7 +244,6 @@ private fun Content(
                         end = paddingValues.calculateStartPadding(LocalLayoutDirection.current)
                     )
                 )
-                .navigationBarsPadding()
         ) {
 
             // Screen title
@@ -654,6 +653,7 @@ private fun ButtonsSection(onEventSend: (Event) -> Unit) {
             .padding(
                 vertical = SPACING_MEDIUM.dp
             )
+            .navigationBarsPadding()
     ) {
         WrapButton(
             modifier = Modifier.fillMaxWidth(),

--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/transactions/detail/TransactionDetailsScreen.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/transactions/detail/TransactionDetailsScreen.kt
@@ -125,11 +125,11 @@ private fun Content(
                     end = paddingValues.calculateEndPadding(LocalLayoutDirection.current)
                 )
             )
-            .navigationBarsPadding()
     ) {
         Column(
             modifier = Modifier
                 .verticalScroll(rememberScrollState())
+                .navigationBarsPadding()
         ) {
             ContentTitle(title = state.title)
 

--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/add/AddDocumentScreen.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/add/AddDocumentScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -185,13 +184,6 @@ private fun Content(
                         start = paddingValues.calculateStartPadding(layoutDirection),
                         end = paddingValues.calculateEndPadding(layoutDirection)
                     )
-                )
-                .then(
-                    if (!state.showFooterScanner) {
-                        Modifier.navigationBarsPadding()
-                    } else {
-                        Modifier
-                    }
                 ),
             state = state,
             onEventSend = onEventSend,
@@ -253,6 +245,7 @@ private fun MainContent(
             Options(
                 options = state.options,
                 modifier = Modifier.fillMaxSize(),
+                footerIsShown = state.showFooterScanner,
                 onOptionClicked = { itemId ->
                     onEventSend(
                         Event.IssueDocument(
@@ -270,6 +263,7 @@ private fun MainContent(
 @Composable
 private fun Options(
     options: List<AddDocumentUi>,
+    footerIsShown: Boolean,
     modifier: Modifier = Modifier,
     onOptionClicked: (itemId: String) -> Unit,
 ) {
@@ -291,7 +285,17 @@ private fun Options(
             }
             if (index == options.lastIndex) {
                 item {
-                    Spacer(modifier = Modifier.height(SPACING_MEDIUM.dp))
+                    Spacer(
+                        modifier = Modifier
+                            .padding(bottom = SPACING_MEDIUM.dp)
+                            .then(
+                                if (!footerIsShown) {
+                                    Modifier.navigationBarsPadding()
+                                } else {
+                                    Modifier
+                                }
+                            )
+                    )
                 }
             }
         }

--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/offer/DocumentOfferScreen.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/offer/DocumentOfferScreen.kt
@@ -173,9 +173,7 @@ private fun Content(
         } else {
             // Screen Main Content
             MainContent(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(bottom = SPACING_SMALL.dp),
+                modifier = Modifier.fillMaxSize(),
                 documents = state.documents,
             )
         }


### PR DESCRIPTION
This commit refactors the navigation bar padding in several screens.

Key changes:
- In `AddDocumentScreen.kt`, the `navigationBarsPadding` modifier was removed from the main content `Column` and added to the `Spacer` within the `Options` composable, conditional on `footerIsShown`.
- In `DocumentDetailsScreen.kt`, `navigationBarsPadding` was removed from the main `Column` and added to the `WrapButton` within the `Column`.
- In `TransactionDetailsScreen.kt`, `navigationBarsPadding` was removed from the outer `Column` and added to the inner scrollable `Column`.
- In `DocumentOfferScreen.kt`, the bottom padding was removed from the `MainContent` modifier.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable