### PR TITLE
Set SDK for Robolectric tests to Vanilla Ice Cream

### DIFF
--- a/common-feature/src/test/java/eu/europa/ec/commonfeature/interactor/TestBiometricInteractor.kt
+++ b/common-feature/src/test/java/eu/europa/ec/commonfeature/interactor/TestBiometricInteractor.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.commonfeature.interactor
 
+import android.os.Build
 import eu.europa.ec.authenticationlogic.controller.authentication.BiometricAuthenticationController
 import eu.europa.ec.authenticationlogic.controller.authentication.BiometricsAuthenticate
 import eu.europa.ec.authenticationlogic.controller.authentication.BiometricsAvailability
@@ -42,7 +43,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(application = TestApplication::class, sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
 class TestBiometricInteractor {
 
     @get:Rule

--- a/common-feature/src/test/java/eu/europa/ec/commonfeature/interactor/TestDeviceAuthenticationInteractor.kt
+++ b/common-feature/src/test/java/eu/europa/ec/commonfeature/interactor/TestDeviceAuthenticationInteractor.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.commonfeature.interactor
 
+import android.os.Build
 import eu.europa.ec.authenticationlogic.controller.authentication.BiometricsAvailability
 import eu.europa.ec.authenticationlogic.controller.authentication.DeviceAuthenticationController
 import eu.europa.ec.authenticationlogic.controller.authentication.DeviceAuthenticationResult
@@ -35,7 +36,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(application = TestApplication::class, sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
 class TestDeviceAuthenticationInteractor {
 
     @Mock

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestHomeInteractor.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestHomeInteractor.kt
@@ -19,6 +19,7 @@ package eu.europa.ec.dashboardfeature.interactor
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.content.Context
+import android.os.Build
 import eu.europa.ec.corelogic.config.WalletCoreConfig
 import eu.europa.ec.corelogic.controller.WalletCoreDocumentsController
 import eu.europa.ec.resourceslogic.provider.ResourceProvider
@@ -42,7 +43,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowBluetoothAdapter
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(application = TestApplication::class, sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
 class TestHomeInteractor {
 
     @get:Rule

--- a/proximity-feature/src/test/java/eu/europa/ec/proximityfeature/interactor/TestProximityQRInteractor.kt
+++ b/proximity-feature/src/test/java/eu/europa/ec/proximityfeature/interactor/TestProximityQRInteractor.kt
@@ -16,6 +16,7 @@
 
 package eu.europa.ec.proximityfeature.interactor
 
+import android.os.Build
 import androidx.activity.ComponentActivity
 import eu.europa.ec.commonfeature.config.PresentationMode
 import eu.europa.ec.commonfeature.config.RequestUriConfig
@@ -55,7 +56,7 @@ import org.robolectric.annotation.Config
 import java.net.URI
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(application = TestApplication::class, sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
 class TestProximityQRInteractor {
 
     @get:Rule


### PR DESCRIPTION
The Robolectric tests were updated to use the Vanilla Ice Cream SDK. This ensures that the tests are run against the latest version of the Android SDK, which can help to identify and fix compatibility issues early on.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?
 
Run all unit tests locally and confirmed that pipeline Actions build successfully.

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable