### PR TITLE
Update JDK for tests to 21 and configure toolchain resolver

### DIFF
--- a/build-logic/convention/src/main/kotlin/project/convention/logic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/project/convention/logic/KotlinAndroid.kt
@@ -20,8 +20,12 @@ import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -109,5 +113,14 @@ private fun Project.configureKotlin() {
                 "-opt-in=kotlinx.coroutines.FlowPreview",
             )
         }
+    }
+
+    val toolchains = extensions.getByType<JavaToolchainService>()
+    tasks.withType<Test>().configureEach {
+        javaLauncher.set(
+            toolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(21))
+            }
+        )
     }
 }

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -29,7 +29,7 @@ Runs all the unit tests
 [bundle exec] fastlane android deploy
 ```
 
-Build Wallet and upload it to appcenter
+Build & Deploy Wallet
 
 ### android prepare_binary
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,9 +13,9 @@
 # ANY KIND, either express or implied. See the Licence for the specific language
 # governing permissions and limitations under the Licence.
 #
-
 org.gradle.jvmargs=-Xmx8192m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.enableR8.fullMode=false
+toolChainResolverVersion=1.0.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,10 @@
  */
 
 pluginManagement {
+    val toolChainResolverVersion: String by extra
+    plugins {
+        id("org.gradle.toolchains.foojay-resolver-convention") version toolChainResolverVersion
+    }
     includeBuild("build-logic")
     repositories {
         google()
@@ -22,6 +26,7 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
@@ -36,6 +41,10 @@ dependencyResolutionManagement {
         }
         mavenLocal()
     }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 rootProject.name = "EUDI Wallet"


### PR DESCRIPTION
This commit updates the Java Development Kit (JDK) used for running tests to version 21. It also introduces and configures the `foojay-resolver-convention` plugin to manage Java toolchains.

Key changes:
- Modified `KotlinAndroid.kt` to set the Java launcher for tests to use JDK 21 via the `JavaToolchainService`.
- Added the `foojay-resolver-convention` plugin to `settings.gradle.kts` and defined its version in `gradle.properties`.
- Updated `fastlane/README.md` to reflect the build and deploy process.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable