### PR TITLE
Fix(theme): Remove "NEW" from comment

### DIFF
--- a/resources-logic/src/main/java/eu/europa/ec/resourceslogic/theme/values/ThemeColors.kt
+++ b/resources-logic/src/main/java/eu/europa/ec/resourceslogic/theme/values/ThemeColors.kt
@@ -132,7 +132,7 @@ class ThemeColors {
         private const val eudiw_theme_dark_surfaceContainerHighest: Long = 0xFF353535
         private const val eudiw_theme_dark_surfaceTint: Long = eudiw_theme_dark_surface
 
-        // NEW — Dark theme fixed accent roles (same values as light).
+        // Dark theme fixed accent roles (same values as light).
         private const val eudiw_theme_dark_primaryFixed: Long = 0xFFD4DEF7
         private const val eudiw_theme_dark_primaryFixedDim: Long = 0xFFA8BEF0
         private const val eudiw_theme_dark_onPrimaryFixed: Long = 0xFF08122B


### PR DESCRIPTION
Removes the word "NEW" from a comment describing dark theme fixed accent roles in `ThemeColors.kt`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable