### PR TITLE
feat(UI): Set selected text color in bottom navigation

### DIFF
--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/component/BottomNavigation.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/component/BottomNavigation.kt
@@ -86,7 +86,8 @@ fun BottomNavigationBar(navController: NavController) {
                 colors = NavigationBarItemDefaults.colors()
                     .copy(
                         selectedIndicatorColor = MaterialTheme.colorScheme.primary,
-                        selectedIconColor = MaterialTheme.colorScheme.onPrimary
+                        selectedIconColor = MaterialTheme.colorScheme.onPrimary,
+                        selectedTextColor = MaterialTheme.colorScheme.onSurface,
                     ),
                 selected = currentDestination?.hierarchy?.any {
                     it.route == screen.route


### PR DESCRIPTION
This commit updates the `BottomNavigation` component to set the `selectedTextColor` for a navigation item to `MaterialTheme.colorScheme.onSurface`. This ensures that the text color of the selected item is explicitly defined.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable