### PR TITLE
refactor: Rename issuerCredentialId to credentialIssuerId

### DIFF
--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/AddDocumentInteractor.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/interactor/AddDocumentInteractor.kt
@@ -122,7 +122,7 @@ class AddDocumentInteractorImpl(
                                 ))
                             .map { doc ->
                                 AddDocumentUi(
-                                    issuerCredentialId = doc.credentialIssuerId,
+                                    credentialIssuerId = doc.credentialIssuerId,
                                     itemData = ListItemDataUi(
                                         itemId = doc.configurationId,
                                         mainContentData = ListItemMainContentDataUi.Text(text = doc.name),
@@ -132,7 +132,7 @@ class AddDocumentInteractorImpl(
                                     )
                                 )
                             }
-                            .groupBy { it.issuerCredentialId }
+                            .groupBy { it.credentialIssuerId }
                             .entries
                             .map { (issuer, items) -> issuer to items }
 

--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/add/AddDocumentScreen.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/add/AddDocumentScreen.kt
@@ -383,7 +383,7 @@ private fun IssuanceAddDocumentScreenPreview() {
                         "issuer1",
                         listOf(
                             AddDocumentUi(
-                                issuerCredentialId = "issuer1",
+                                credentialIssuerId = "issuer1",
                                 itemData = ListItemDataUi(
                                     itemId = "configId1",
                                     mainContentData = ListItemMainContentDataUi.Text(text = "National ID"),
@@ -398,7 +398,7 @@ private fun IssuanceAddDocumentScreenPreview() {
                         "issuer2",
                         listOf(
                             AddDocumentUi(
-                                issuerCredentialId = "issuer2",
+                                credentialIssuerId = "issuer2",
                                 itemData = ListItemDataUi(
                                     itemId = "configId2",
                                     mainContentData = ListItemMainContentDataUi.Text(text = "Driving Licence"),
@@ -440,7 +440,7 @@ private fun DashboardAddDocumentScreenPreview() {
                         "issuer1",
                         listOf(
                             AddDocumentUi(
-                                issuerCredentialId = "issuer1",
+                                credentialIssuerId = "issuer1",
                                 itemData = ListItemDataUi(
                                     itemId = "configId1",
                                     mainContentData = ListItemMainContentDataUi.Text(text = "National ID"),
@@ -455,7 +455,7 @@ private fun DashboardAddDocumentScreenPreview() {
                         "issuer2",
                         listOf(
                             AddDocumentUi(
-                                issuerCredentialId = "issuer2",
+                                credentialIssuerId = "issuer2",
                                 itemData = ListItemDataUi(
                                     itemId = "configId2",
                                     mainContentData = ListItemMainContentDataUi.Text(text = "Driving Licence"),

--- a/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/add/model/AddDocumentUi.kt
+++ b/issuance-feature/src/main/java/eu/europa/ec/issuancefeature/ui/add/model/AddDocumentUi.kt
@@ -19,6 +19,6 @@ package eu.europa.ec.issuancefeature.ui.add.model
 import eu.europa.ec.uilogic.component.ListItemDataUi
 
 data class AddDocumentUi(
-    val issuerCredentialId: String,
+    val credentialIssuerId: String,
     val itemData: ListItemDataUi,
 )

--- a/issuance-feature/src/test/java/eu/europa/ec/issuancefeature/util/TestData.kt
+++ b/issuance-feature/src/test/java/eu/europa/ec/issuancefeature/util/TestData.kt
@@ -59,7 +59,7 @@ internal const val mockedIssuerId = "issuerId"
 private const val mockedConfigIssuerId = "configurationId"
 
 internal val mockedPidOptionItemUi = AddDocumentUi(
-    issuerCredentialId = mockedIssuerId,
+    credentialIssuerId = mockedIssuerId,
     itemData = ListItemDataUi(
         itemId = mockedConfigIssuerId,
         mainContentData = ListItemMainContentDataUi.Text(text = mockedPidDocName),
@@ -68,7 +68,7 @@ internal val mockedPidOptionItemUi = AddDocumentUi(
 )
 
 internal val mockedMdlOptionItemUi = AddDocumentUi(
-    issuerCredentialId = mockedIssuerId,
+    credentialIssuerId = mockedIssuerId,
     itemData = ListItemDataUi(
         itemId = mockedConfigIssuerId,
         mainContentData = ListItemMainContentDataUi.Text(text = mockedMdlDocName),
@@ -77,7 +77,7 @@ internal val mockedMdlOptionItemUi = AddDocumentUi(
 )
 
 internal val mockedAgeOptionItemUi = AddDocumentUi(
-    issuerCredentialId = mockedIssuerId,
+    credentialIssuerId = mockedIssuerId,
     itemData = ListItemDataUi(
         itemId = mockedConfigIssuerId,
         mainContentData = ListItemMainContentDataUi.Text(text = mockedAgeVerificationDocName),
@@ -86,7 +86,7 @@ internal val mockedAgeOptionItemUi = AddDocumentUi(
 )
 
 internal val mockedPhotoIdOptionItemUi = AddDocumentUi(
-    issuerCredentialId = mockedIssuerId,
+    credentialIssuerId = mockedIssuerId,
     itemData = ListItemDataUi(
         itemId = mockedConfigIssuerId,
         mainContentData = ListItemMainContentDataUi.Text(text = mockedPhotoIdDocName),


### PR DESCRIPTION
This commit renames the `issuerCredentialId` property to `credentialIssuerId` within the `AddDocumentUi` data class for better clarity and consistency.

The change is applied across the issuance feature, including the `AddDocumentInteractor`, `AddDocumentScreen`, and related test data.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable