### PR TITLE
feat: Use Locale.forLanguageTag("es") for locale creation

### DIFF
--- a/issuance-feature/src/test/java/eu/europa/ec/issuancefeature/interactor/TestDocumentOfferInteractor.kt
+++ b/issuance-feature/src/test/java/eu/europa/ec/issuancefeature/interactor/TestDocumentOfferInteractor.kt
@@ -299,7 +299,7 @@ class TestDocumentOfferInteractor {
                         display = listOf(
                             Display(
                                 name = mockedOfferedDocumentName,
-                                locale = Locale("es")
+                                locale = Locale.forLanguageTag("es")
                             )
                         )
                     )


### PR DESCRIPTION
This commit updates the creation of a Spanish locale in `TestDocumentOfferInteractor.kt`. It replaces the deprecated `Locale("es")` constructor with the modern `Locale.forLanguageTag("es")` method. This change aligns with best practices for instantiating locales.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable