### PR TITLE
Feat: Use "Unknown" for documents with no issuer

### DIFF
--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/DocumentsInteractor.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/interactor/DocumentsInteractor.kt
@@ -305,6 +305,7 @@ class DocumentsInteractorImpl(
                                 document.localizedIssuerMetadata(userLocale)
 
                             val issuerName = localizedIssuerMetadata?.name
+                                ?: resourceProvider.getString(R.string.documents_screen_filters_unknown_issuer)
 
                             val documentIdentifier = document.toDocumentIdentifier()
 
@@ -316,7 +317,7 @@ class DocumentsInteractorImpl(
 
                             val documentSearchTags = buildList {
                                 add(documentName)
-                                if (!issuerName.isNullOrBlank()) {
+                                if (issuerName.isNotBlank()) {
                                     add(issuerName)
                                 }
                             }
@@ -416,6 +417,7 @@ class DocumentsInteractorImpl(
                                 document.localizedIssuerMetadata(userLocale)
 
                             val issuerName = localizedIssuerMetadata?.name
+                                ?: resourceProvider.getString(R.string.documents_screen_filters_unknown_issuer)
 
                             val documentIdentifier = document.toDocumentIdentifier()
 
@@ -427,7 +429,7 @@ class DocumentsInteractorImpl(
 
                             val documentSearchTags = buildList {
                                 add(documentName)
-                                if (!issuerName.isNullOrBlank()) {
+                                if (issuerName.isNotBlank()) {
                                     add(issuerName)
                                 }
                             }
@@ -791,18 +793,14 @@ class DocumentsInteractorImpl(
     private fun addIssuerFilter(documents: FilterableList): List<FilterItem> {
         return documents.items
             .distinctBy { (it.attributes as DocumentsFilterableAttributes).issuer }
-            .mapNotNull { filterableItem ->
+            .map { filterableItem ->
                 with(filterableItem.attributes as DocumentsFilterableAttributes) {
-                    if (issuer != null) {
-                        FilterItem(
-                            id = issuer,
-                            name = issuer,
-                            selected = true,
-                            isDefault = true,
-                        )
-                    } else {
-                        null
-                    }
+                    FilterItem(
+                        id = issuer,
+                        name = issuer,
+                        selected = true,
+                        isDefault = true,
+                    )
                 }
             }
     }

--- a/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/list/model/DocumentsFilterableAttributes.kt
+++ b/dashboard-feature/src/main/java/eu/europa/ec/dashboardfeature/ui/documents/list/model/DocumentsFilterableAttributes.kt
@@ -25,7 +25,7 @@ data class DocumentsFilterableAttributes(
     val name: String,
     val expiryDate: Instant?,
     val issuedDate: Instant?,
-    val issuer: String?,
+    val issuer: String,
     val category: DocumentCategory,
     val isRevoked: Boolean,
 ) : FilterableAttributes

--- a/resources-logic/src/main/res/values/strings.xml
+++ b/resources-logic/src/main/res/values/strings.xml
@@ -279,6 +279,7 @@
     <string name="documents_screen_filters_filter_by_expiry_period_4">Before today (expired)</string>
     <string name="documents_screen_filters_apply">@string/generic_filters_apply</string>
     <string name="documents_screen_filters_reset">@string/generic_filters_reset</string>
+    <string name="documents_screen_filters_unknown_issuer">Unknown</string>
 
     <!-- Transactions Screen -->
     <string name="transactions_screen_title">Transactions</string>


### PR DESCRIPTION
This commit ensures that documents without an issuer name are handled gracefully.

Changes include:
- A new "Unknown" string resource is added for documents with a missing issuer.
- The `DocumentsInteractor` now uses this "Unknown" string as a fallback for the issuer name in document details and search tags.
- The `issuer` property in `DocumentsFilterableAttributes` is now non-nullable to prevent null values in the filter list.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable