### PR TITLE
feat: Add ability to generate a graph of the gradle project dependencies.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,5 +30,11 @@ plugins {
     alias(libs.plugins.baselineprofile) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.androidx.room) apply false
+    alias(libs.plugins.dependencyGraph)
 }
+
+moduleGraphConfig {
+    readmePath.set("wiki/dependency-graph.md")
+}
+
 true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ androidxBiometric = "1.2.0-alpha05"
 androidxAppAuth = "1.0.0"
 coil = "3.4.0"
 constraintlayoutVersion = "1.1.1"
+dependencyGraphPlugin = "0.13.0"
 gmsPlugin = "4.4.4"
 junit4 = "4.13.2"
 kotlin = "2.3.10"
@@ -170,6 +171,7 @@ androidx-room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plug
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
+dependencyGraph = { id = "dev.iurysouza.modulegraph", version.ref = "dependencyGraphPlugin"}
 gms = { id = "com.google.gms.google-services", version.ref = "gmsPlugin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/wiki/dependency-graph.md
+++ b/wiki/dependency-graph.md
@@ -1,0 +1,108 @@
+# Module Graph
+
+```mermaid
+%%{
+  init: {
+    'theme': 'neutral'
+  }
+}%%
+
+graph LR
+  :baseline-profile --> :app
+  :test-feature --> :test-logic
+  :test-feature --> :business-logic
+  :test-feature --> :ui-logic
+  :test-feature --> :network-logic
+  :test-feature --> :resources-logic
+  :test-feature --> :authentication-logic
+  :test-feature --> :core-logic
+  :test-feature --> :analytics-logic
+  :business-logic --> :test-logic
+  :business-logic --> :resources-logic
+  :assembly-logic --> :resources-logic
+  :assembly-logic --> :business-logic
+  :assembly-logic --> :ui-logic
+  :assembly-logic --> :network-logic
+  :assembly-logic --> :analytics-logic
+  :assembly-logic --> :authentication-logic
+  :assembly-logic --> :core-logic
+  :assembly-logic --> :storage-logic
+  :assembly-logic --> :common-feature
+  :assembly-logic --> :startup-feature
+  :assembly-logic --> :dashboard-feature
+  :assembly-logic --> :presentation-feature
+  :assembly-logic --> :proximity-feature
+  :assembly-logic --> :issuance-feature
+  :ui-logic --> :resources-logic
+  :ui-logic --> :business-logic
+  :ui-logic --> :analytics-logic
+  :ui-logic --> :core-logic
+  :ui-logic --> :storage-logic
+  :ui-logic --> :test-logic
+  :authentication-logic --> :resources-logic
+  :authentication-logic --> :business-logic
+  :app --> :baseline-profile
+  :app --> :assembly-logic
+  :common-feature --> :test-feature
+  :common-feature --> :business-logic
+  :common-feature --> :ui-logic
+  :common-feature --> :network-logic
+  :common-feature --> :resources-logic
+  :common-feature --> :analytics-logic
+  :common-feature --> :authentication-logic
+  :common-feature --> :core-logic
+  :presentation-feature --> :test-feature
+  :presentation-feature --> :business-logic
+  :presentation-feature --> :ui-logic
+  :presentation-feature --> :network-logic
+  :presentation-feature --> :resources-logic
+  :presentation-feature --> :analytics-logic
+  :presentation-feature --> :authentication-logic
+  :presentation-feature --> :core-logic
+  :presentation-feature --> :common-feature
+  :dashboard-feature --> :test-feature
+  :dashboard-feature --> :business-logic
+  :dashboard-feature --> :ui-logic
+  :dashboard-feature --> :network-logic
+  :dashboard-feature --> :resources-logic
+  :dashboard-feature --> :analytics-logic
+  :dashboard-feature --> :authentication-logic
+  :dashboard-feature --> :core-logic
+  :dashboard-feature --> :common-feature
+  :storage-logic --> :business-logic
+  :issuance-feature --> :test-feature
+  :issuance-feature --> :business-logic
+  :issuance-feature --> :ui-logic
+  :issuance-feature --> :network-logic
+  :issuance-feature --> :resources-logic
+  :issuance-feature --> :analytics-logic
+  :issuance-feature --> :authentication-logic
+  :issuance-feature --> :core-logic
+  :issuance-feature --> :common-feature
+  :core-logic --> :storage-logic
+  :core-logic --> :resources-logic
+  :core-logic --> :business-logic
+  :core-logic --> :authentication-logic
+  :core-logic --> :network-logic
+  :core-logic --> :test-logic
+  :proximity-feature --> :test-feature
+  :proximity-feature --> :business-logic
+  :proximity-feature --> :ui-logic
+  :proximity-feature --> :network-logic
+  :proximity-feature --> :resources-logic
+  :proximity-feature --> :analytics-logic
+  :proximity-feature --> :authentication-logic
+  :proximity-feature --> :core-logic
+  :proximity-feature --> :common-feature
+  :startup-feature --> :test-feature
+  :startup-feature --> :business-logic
+  :startup-feature --> :ui-logic
+  :startup-feature --> :network-logic
+  :startup-feature --> :resources-logic
+  :startup-feature --> :analytics-logic
+  :startup-feature --> :authentication-logic
+  :startup-feature --> :core-logic
+  :startup-feature --> :common-feature
+  :network-logic --> :business-logic
+  :network-logic --> :test-logic
+```


### PR DESCRIPTION
Add ability to generate a graph of the project's module dependencies.

The graph is generated as a text-based mermaid diagram, which GitHub UI renders graphically.

To regenerate:

```
./gradlew createModuleGraph
```

Results will be written to:

 - `wiki/dependency-graph.md`

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Generated dependency graph, output included as part of this PR: Navigate to `dependency-graph.md` from the changed files, then select "View file" for that file to see how GitHub renders it.

# Checklist:

- [x] I have performed a self-review of my own code
