### PR TITLE
Feat: Configure HTTP client logging based on build type

### DIFF
--- a/network-logic/src/main/java/eu/europa/ec/networklogic/di/NetworkModule.kt
+++ b/network-logic/src/main/java/eu/europa/ec/networklogic/di/NetworkModule.kt
@@ -16,11 +16,16 @@
 
 package eu.europa.ec.networklogic.di
 
+import eu.europa.ec.businesslogic.config.AppBuildType
+import eu.europa.ec.businesslogic.config.ConfigLogic
 import eu.europa.ec.networklogic.repository.WalletAttestationRepository
 import eu.europa.ec.networklogic.repository.WalletAttestationRepositoryImpl
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.DEFAULT
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.ContentType
 import io.ktor.serialization.kotlinx.json.json
@@ -41,9 +46,17 @@ fun provideJson(): Json = Json {
 }
 
 @Single
-fun provideHttpClient(json: Json): HttpClient {
+fun provideHttpClient(json: Json, configLogic: ConfigLogic): HttpClient {
     return HttpClient(Android) {
-        install(Logging)
+
+        install(Logging) {
+            logger = Logger.DEFAULT
+            level = when (configLogic.appBuildType) {
+                AppBuildType.DEBUG -> LogLevel.BODY
+                AppBuildType.RELEASE -> LogLevel.NONE
+            }
+        }
+
         install(ContentNegotiation) {
             json(
                 json = json,


### PR DESCRIPTION
This commit enhances the `HttpClient` by introducing conditional logging based on the application's build type.

Specifically, it injects `ConfigLogic` into the `provideHttpClient` function to access the current `AppBuildType`. The Ktor `Logging` plugin is now configured to:
- Use `LogLevel.BODY` for `DEBUG` builds, enabling detailed logging of request and response bodies.
- Use `LogLevel.NONE` for `RELEASE` builds, disabling logging for production environments.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable