### PR TITLE
Bugfix: Fix screen padding mismatch when showing ContentError.

### DIFF
--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/component/content/ContentScreen.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/component/content/ContentScreen.kt
@@ -156,12 +156,11 @@ fun ContentScreen(
         snackbarHost = snackbarHost,
     ) { padding ->
 
-        val screenPaddingsIgnoringSticky = remember(padding) {
-            screenPaddings(
-                hasStickyBottom = false,
-                append = padding
-            )
-        }
+        val screenPaddingsIgnoringSticky = screenPaddings(
+            hasStickyBottom = false,
+            append = padding,
+            topSpacing = topSpacing
+        )
 
         Box(
             modifier = Modifier.fillMaxSize()


### PR DESCRIPTION
The paddings applied to ContentError were previously remembered using only the Scaffold padding as a key.

When the screen initially had no toolbar (navigatableAction == NONE) and later entered an error state (contentErrorConfig != null), the toolbar was added but the cached paddings were not recomputed. This caused the ContentError title to overlap the toolbar navigation icon.

Screen paddings are now recomputed using the current topSpacing, ensuring ContentError is laid out correctly when the toolbar appears.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable