### PR TITLE
feat: Expose test tags as resource IDs for UI testing

### DIFF
--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/component/wrap/WrapModalBottomSheet.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/component/wrap/WrapModalBottomSheet.kt
@@ -66,6 +66,7 @@ import eu.europa.ec.uilogic.component.utils.SPACING_LARGE
 import eu.europa.ec.uilogic.component.utils.SPACING_MEDIUM
 import eu.europa.ec.uilogic.component.utils.SPACING_SMALL
 import eu.europa.ec.uilogic.component.utils.VSpacer
+import eu.europa.ec.uilogic.extension.exposeTestTagsAsResourceId
 import eu.europa.ec.uilogic.extension.optionalTestTag
 import eu.europa.ec.uilogic.extension.throttledClickable
 import eu.europa.ec.uilogic.mvi.ViewEvent
@@ -125,7 +126,9 @@ fun WrapModalBottomSheet(
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        modifier = modifier,
+        modifier = Modifier
+            .exposeTestTagsAsResourceId()
+            .then(modifier),
         sheetState = sheetState,
         shape = shape,
         dragHandle = dragHandle,

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/container/EudiComponentActivity.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/container/EudiComponentActivity.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import eu.europa.ec.resourceslogic.theme.ThemeManager
+import eu.europa.ec.uilogic.extension.exposeTestTagsAsResourceId
 import eu.europa.ec.uilogic.navigation.IssuanceScreens
 import eu.europa.ec.uilogic.navigation.RouterHost
 import eu.europa.ec.uilogic.navigation.helper.DeepLinkAction
@@ -59,7 +60,9 @@ open class EudiComponentActivity : FragmentActivity() {
     ) {
         ThemeManager.instance.Theme {
             Surface(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .exposeTestTagsAsResourceId()
+                    .fillMaxSize(),
                 color = MaterialTheme.colorScheme.surface
             ) {
                 routerHost.StartFlow {

--- a/ui-logic/src/main/java/eu/europa/ec/uilogic/extension/ModifierExtensions.kt
+++ b/ui-logic/src/main/java/eu/europa/ec/uilogic/extension/ModifierExtensions.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.channels.BufferOverflow
@@ -200,4 +202,11 @@ fun Modifier.optionalTestTag(testTag: String?): Modifier {
             Modifier
         }
     )
+}
+
+fun Modifier.exposeTestTagsAsResourceId(): Modifier {
+    return this
+        .semantics {
+            this.testTagsAsResourceId = true
+        }
 }


### PR DESCRIPTION
This commit introduces a `Modifier.exposeTestTagsAsResourceId()` extension to make Compose `testTag` attributes available as resource IDs in UI tests. This simplifies element lookup for automation frameworks.

The new modifier has been applied to the root `Surface` in `EudiComponentActivity` and the `ModalBottomSheet` in `WrapModalBottomSheet` to enable this functionality at the top level of the UI hierarchy.

## Type of change
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable