### PR TITLE
refactor: Standardize "quick pin" to "pin" in user-facing strings

### DIFF
--- a/resources-logic/src/main/res/values/strings.xml
+++ b/resources-logic/src/main/res/values/strings.xml
@@ -143,28 +143,28 @@
     <!--endregion-->
 
     <!-- region Quick Pin -->
-    <string name="quick_pin_invalid_error">Invalid quick pin</string>
+    <string name="quick_pin_invalid_error">Invalid pin</string>
     <string name="quick_pin_numerical_rule_invalid_error_message">Only numerical values are allowed</string>
     <string name="quick_pin_non_match">Pins do not match</string>
 
     <string name="quick_pin_create_title">Welcome to your Wallet</string>
     <string name="quick_pin_create_enter_subtitle">Secure your wallet with a PIN code and connect to your National System.</string>
-    <string name="quick_pin_create_reenter_subtitle">Re-enter the quick pin</string>
+    <string name="quick_pin_create_reenter_subtitle">Re-enter the pin</string>
 
-    <string name="quick_pin_change_title">Change quick pin</string>
+    <string name="quick_pin_change_title">Change pin</string>
     <string name="quick_pin_change_validate_current_subtitle">Type your current pin</string>
-    <string name="quick_pin_change_enter_new_subtitle">Select a quick pin for future logins</string>
-    <string name="quick_pin_change_reenter_new_subtitle">Re-enter the new quick pin</string>
+    <string name="quick_pin_change_enter_new_subtitle">Select a pin for future logins</string>
+    <string name="quick_pin_change_reenter_new_subtitle">Re-enter the new pin</string>
 
     <string name="quick_pin_create_success_text">Your wallet is secured!</string>
     <string name="quick_pin_create_success_description">To activate your wallet, connect to your National System to add your Digital ID.</string>
     <string name="quick_pin_create_success_btn">Add my Digital ID</string>
     <string name="quick_pin_change_success_text">@string/generic_success</string>
-    <string name="quick_pin_change_success_description">You successfully changed the quick pin</string>
+    <string name="quick_pin_change_success_description">You successfully changed the pin</string>
     <string name="quick_pin_change_success_btn">BACK TO HOME</string>
 
-    <string name="quick_pin_bottom_sheet_cancel_title">Cancel quick pin changing?</string>
-    <string name="quick_pin_bottom_sheet_cancel_subtitle">Cancel will redirect you back to the home without changing the quick pin</string>
+    <string name="quick_pin_bottom_sheet_cancel_title">Cancel pin changing?</string>
+    <string name="quick_pin_bottom_sheet_cancel_subtitle">Cancel will redirect you back to the home without changing the pin</string>
     <string name="quick_pin_bottom_sheet_cancel_primary_button_text">@string/generic_continue_capitalized</string>
     <string name="quick_pin_bottom_sheet_cancel_secondary_button_text">@string/generic_cancel_capitalized</string>
     <!--endregion-->


### PR DESCRIPTION
This commit removes the word "quick" from all user-facing strings related to PIN functionality in `strings.xml`. The change standardizes the terminology to just "pin" for better clarity and consistency across the application.

This affects titles, subtitles, error messages, and button text related to creating, changing, and canceling a PIN.

## Type of change
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable