### PR TITLE
Bugfix: Add null-safety for claim values

### DIFF
--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentHelper.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentHelper.kt
@@ -370,17 +370,21 @@ private fun insertPath(
     return if (path.value.size == 1) {
         // Leaf node (Primitive or Nested Structure)
         if (existingNode == null && currentClaim != null) {
-            val accumulatedClaims: MutableList<ClaimDomain> = mutableListOf()
-            createKeyValue(
-                item = currentClaim.value!!,
-                groupKey = currentClaim.identifier,
-                resourceProvider = resourceProvider,
-                uuidProvider = uuidProvider,
-                claimMetaData = currentClaim.issuerMetadata,
-                disclosurePath = disclosurePath,
-                allItems = accumulatedClaims,
-            )
-            tree + accumulatedClaims
+            currentClaim.value?.let { safeClaimValue ->
+                val accumulatedClaims: MutableList<ClaimDomain> = mutableListOf()
+
+                createKeyValue(
+                    item = safeClaimValue,
+                    groupKey = currentClaim.identifier,
+                    resourceProvider = resourceProvider,
+                    uuidProvider = uuidProvider,
+                    claimMetaData = currentClaim.issuerMetadata,
+                    disclosurePath = disclosurePath,
+                    allItems = accumulatedClaims,
+                )
+
+                tree + accumulatedClaims
+            } ?: tree // No value to add (claim value is null), return unchanged
         } else {
             tree // Already exists or not available, return unchanged
         }


### PR DESCRIPTION
This commit adds null-safety checks when processing claim values.

The key changes include:
- In `DocumentHelper`, the `addToTree` method now safely handles cases where a `currentClaim` has a `null` value, preventing it from being added to the claims tree.
- In `TransactionDetailsInteractor`, claim processing logic now checks if a `presentedClaim` has a `null` value before attempting to use it, ensuring that only claims with non-null values are processed and transformed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable