### PR TITLE
feat: support DCQL null wildcard matching and typed ClaimPath

### DIFF
--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
@@ -157,7 +157,7 @@ object RequestTransformer {
 
                         is DomainDocumentFormat.SdJwtVc -> sdJwtItems.add(
                             SdJwtVcItem(
-                                path = ClaimPathDomain.toSdJwtVcPath(selectedItemId)
+                                path = ClaimPathDomain.toSdJwtVcClaimPath(selectedItemId)
                             )
                         )
 

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/request/transformer/RequestTransformer.kt
@@ -26,6 +26,7 @@ import eu.europa.ec.corelogic.extension.toClaimPath
 import eu.europa.ec.corelogic.extension.toClaimPaths
 import eu.europa.ec.corelogic.model.ClaimPathDomain
 import eu.europa.ec.corelogic.model.ClaimPathDomain.Companion.isPrefixOf
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPath
 import eu.europa.ec.eudi.iso18013.transfer.response.DisclosedDocument
 import eu.europa.ec.eudi.iso18013.transfer.response.DisclosedDocuments
 import eu.europa.ec.eudi.iso18013.transfer.response.RequestedDocument
@@ -155,11 +156,10 @@ object RequestTransformer {
 
                     when (documentPayload.domainDocFormat) {
 
-                        is DomainDocumentFormat.SdJwtVc -> sdJwtItems.add(
-                            SdJwtVcItem(
-                                path = ClaimPathDomain.toSdJwtVcClaimPath(selectedItemId)
-                            )
-                        )
+                        is DomainDocumentFormat.SdJwtVc -> {
+                            val claimPath = ClaimPath(ClaimPathDomain.toSdJwtVcClaimPath(selectedItemId))
+                            sdJwtItems.add(SdJwtVcItem(claimPath))
+                        }
 
                         is DomainDocumentFormat.MsoMdoc -> {
                             val elementIdentifier = ClaimPathDomain.toElementIdentifier(

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentHelper.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentHelper.kt
@@ -325,7 +325,7 @@ private fun insertPath(
 
     val userLocale = resourceProvider.getLocale()
 
-    val key = path.value.first()
+    val key = path.value.first().toString()
 
     val existingNode = tree.find {
         when (val type = disclosurePath.type) {

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentHelper.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentHelper.kt
@@ -28,6 +28,7 @@ import eu.europa.ec.corelogic.extension.sortRecursivelyBy
 import eu.europa.ec.corelogic.model.ClaimDomain
 import eu.europa.ec.corelogic.model.ClaimPathDomain
 import eu.europa.ec.corelogic.model.ClaimType
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
 import eu.europa.ec.eudi.wallet.document.IssuedDocument
 import eu.europa.ec.eudi.wallet.document.format.DocumentClaim
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocClaim
@@ -133,7 +134,7 @@ fun createKeyValue(
                 ClaimDomain.Group(
                     key = groupKey,
                     displayTitle = displayTitle,
-                    path = ClaimPathDomain(listOf(uuidProvider.provideUuid()), disclosurePath.type),
+                    path = ClaimPathDomain(listOf(ClaimPathElement.Claim(uuidProvider.provideUuid())), disclosurePath.type),
                     items = children
                 )
             )
@@ -227,7 +228,7 @@ fun createKeyValue(
                                     )
                                 } $position",
                                 path = ClaimPathDomain(
-                                    listOf(uuidProvider.provideUuid()),
+                                    listOf(ClaimPathElement.Claim(uuidProvider.provideUuid())),
                                     disclosurePath.type
                                 ),
                                 items = entryChildren

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/extension/DocItemExtensions.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/extension/DocItemExtensions.kt
@@ -31,14 +31,10 @@ fun DocItem.toClaimPath(): ClaimPathDomain {
             type = ClaimType.MsoMdoc(namespace = this.namespace)
         )
 
-        is SdJwtVcItem -> {
-            @Suppress("UNCHECKED_CAST")
-            val elements = this.path as List<ClaimPathElement>
-            ClaimPathDomain(
-                value = elements,
-                type = ClaimType.SdJwtVc
-            )
-        }
+        is SdJwtVcItem -> ClaimPathDomain(
+            value = this.path.value,
+            type = ClaimType.SdJwtVc
+        )
 
         else -> ClaimPathDomain(
             value = emptyList(),

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/extension/DocItemExtensions.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/extension/DocItemExtensions.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.corelogic.extension
 
 import eu.europa.ec.corelogic.model.ClaimPathDomain
 import eu.europa.ec.corelogic.model.ClaimType
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPath
 import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
 import eu.europa.ec.eudi.iso18013.transfer.response.DocItem
 import eu.europa.ec.eudi.iso18013.transfer.response.device.MsoMdocItem
@@ -30,10 +31,14 @@ fun DocItem.toClaimPath(): ClaimPathDomain {
             type = ClaimType.MsoMdoc(namespace = this.namespace)
         )
 
-        is SdJwtVcItem -> ClaimPathDomain(
-            value = this.path.value,
-            type = ClaimType.SdJwtVc
-        )
+        is SdJwtVcItem -> {
+            @Suppress("UNCHECKED_CAST")
+            val elements = this.path as List<ClaimPathElement>
+            ClaimPathDomain(
+                value = elements,
+                type = ClaimType.SdJwtVc
+            )
+        }
 
         else -> ClaimPathDomain(
             value = emptyList(),

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/extension/DocItemExtensions.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/extension/DocItemExtensions.kt
@@ -17,22 +17,27 @@
 package eu.europa.ec.corelogic.extension
 
 import eu.europa.ec.corelogic.model.ClaimPathDomain
-import eu.europa.ec.corelogic.model.ClaimPathDomain.Companion.toClaimPathDomain
 import eu.europa.ec.corelogic.model.ClaimType
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
 import eu.europa.ec.eudi.iso18013.transfer.response.DocItem
 import eu.europa.ec.eudi.iso18013.transfer.response.device.MsoMdocItem
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.SdJwtVcItem
 
 fun DocItem.toClaimPath(): ClaimPathDomain {
-    val type = when (this) {
-        is MsoMdocItem -> ClaimType.MsoMdoc(namespace = this.namespace)
-        is SdJwtVcItem -> ClaimType.SdJwtVc
-        else -> ClaimType.Unknown
-    }
-
     return when (this) {
-        is MsoMdocItem -> listOf(this.elementIdentifier)
-        is SdJwtVcItem -> this.path
-        else -> emptyList()
-    }.toClaimPathDomain(type = type)
+        is MsoMdocItem -> ClaimPathDomain(
+            value = listOf(ClaimPathElement.Claim(this.elementIdentifier)),
+            type = ClaimType.MsoMdoc(namespace = this.namespace)
+        )
+
+        is SdJwtVcItem -> ClaimPathDomain(
+            value = this.path.value,
+            type = ClaimType.SdJwtVc
+        )
+
+        else -> ClaimPathDomain(
+            value = emptyList(),
+            type = ClaimType.Unknown
+        )
+    }
 }

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/extension/DocumentClaimExtensions.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/extension/DocumentClaimExtensions.kt
@@ -18,6 +18,7 @@ package eu.europa.ec.corelogic.extension
 
 import eu.europa.ec.corelogic.model.ClaimPathDomain
 import eu.europa.ec.corelogic.model.ClaimType
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
 import eu.europa.ec.eudi.wallet.document.format.DocumentClaim
 import eu.europa.ec.eudi.wallet.document.format.MsoMdocClaim
 import eu.europa.ec.eudi.wallet.document.format.SdJwtVcClaim
@@ -42,11 +43,11 @@ import eu.europa.ec.eudi.wallet.document.format.SdJwtVcClaim
  * - The type of the returned [ClaimPathDomain] will be [ClaimType.MsoMdoc], which includes the claim's namespace.
  */
 fun DocumentClaim.toClaimPaths(
-    parentPath: List<String> = emptyList()
+    parentPath: List<ClaimPathElement> = emptyList()
 ): List<ClaimPathDomain> {
     return when (this) {
         is SdJwtVcClaim -> {
-            val currentPath: List<String> = parentPath + this.identifier
+            val currentPath = parentPath + ClaimPathElement.Claim(this.identifier)
             if (children.isEmpty() || this.value is Collection<*>) {
                 listOf(ClaimPathDomain(value = currentPath, type = ClaimType.SdJwtVc))
             } else {
@@ -59,7 +60,7 @@ fun DocumentClaim.toClaimPaths(
         is MsoMdocClaim -> {
             listOf(
                 ClaimPathDomain(
-                    value = listOf(this.identifier),
+                    value = listOf(ClaimPathElement.Claim(this.identifier)),
                     type = ClaimType.MsoMdoc(this.nameSpace)
                 )
             )

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/model/ClaimPathDomain.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/model/ClaimPathDomain.kt
@@ -49,12 +49,11 @@ data class ClaimPathDomain(
                 .first()
         }
 
-        fun toSdJwtVcClaimPath(itemId: String): ClaimPath {
-            val elements = itemId
+        fun toSdJwtVcClaimPath(itemId: String): List<ClaimPathElement> {
+            return itemId
                 .split(PATH_SEPARATOR)
                 .drop(1)
                 .map { ClaimPathElement.Claim(it) }
-            return ClaimPath(elements)
         }
 
         /**
@@ -111,7 +110,7 @@ data class ClaimPathDomain(
             namespaceOrNull?.let { safeNamespace ->
                 add(safeNamespace)
             }
-            addAll(value.map { it.toString() })
+            addAll(value.map { element -> element.toString() })
         }.joinToString(separator = PATH_SEPARATOR)
 
         return finalId

--- a/core-logic/src/main/java/eu/europa/ec/corelogic/model/ClaimPathDomain.kt
+++ b/core-logic/src/main/java/eu/europa/ec/corelogic/model/ClaimPathDomain.kt
@@ -16,6 +16,8 @@
 
 package eu.europa.ec.corelogic.model
 
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPath
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
 import eu.europa.ec.eudi.wallet.document.NameSpace
 
 sealed interface ClaimType {
@@ -26,7 +28,7 @@ sealed interface ClaimType {
 }
 
 data class ClaimPathDomain(
-    val value: List<String>,
+    val value: List<ClaimPathElement>,
     val type: ClaimType,
 ) {
 
@@ -47,43 +49,55 @@ data class ClaimPathDomain(
                 .first()
         }
 
-        fun toSdJwtVcPath(itemId: String): List<String> {
-            return itemId
+        fun toSdJwtVcClaimPath(itemId: String): ClaimPath {
+            val elements = itemId
                 .split(PATH_SEPARATOR)
                 .drop(1)
+                .map { ClaimPathElement.Claim(it) }
+            return ClaimPath(elements)
         }
 
+        /**
+         * Converts a list of strings to a [ClaimPathDomain] where all elements
+         * are treated as [ClaimPathElement.Claim]s. Use this for paths from stored
+         * credentials or transaction logs where no wildcards are expected.
+         */
         fun List<String>.toClaimPathDomain(type: ClaimType): ClaimPathDomain {
-            return ClaimPathDomain(value = this, type = type)
+            return ClaimPathDomain(
+                value = this.map { ClaimPathElement.Claim(it) },
+                type = type
+            )
         }
 
         /**
          * Checks whether this [ClaimPathDomain] is a prefix of another [ClaimPathDomain].
          *
-         * A prefix match means that all elements of this path must appear in the same order
-         * and at the beginning of the [other] path. This allows partial matches useful in scenarios
-         * where the verifier requests a parent claim (e.g., `"address"`) and the wallet contains
-         * deeper nested claims (e.g., `"address.street"`, `"address.city"`).
-         *
-         * Examples:
-         * ```
-         * ClaimPath(listOf("address")).isPrefixOf(ClaimPath(listOf("address", "city"))) == true
-         * ClaimPath(listOf("claim1", "a")).isPrefixOf(ClaimPath(listOf("claim1", "a", "b"))) == true
-         * ClaimPath(listOf("name")).isPrefixOf(ClaimPath(listOf("name_birth"))) == false
-         * ```
+         * Supports DCQL wildcard matching via [ClaimPathElement.AllArrayElements]:
+         * - A wildcard element matches any value at that position.
+         * - Trailing wildcard elements are tolerated when the available path ends
+         *   at the array claim itself.
          *
          * @param other The [ClaimPathDomain] to compare against.
          * @return `true` if this path is a prefix of [other]; `false` otherwise.
          */
         fun ClaimPathDomain.isPrefixOf(other: ClaimPathDomain): Boolean {
-            return this.value.size <= other.value.size &&
-                    this.type == other.type &&
-                    this.value.zip(other.value).all { (a, b) -> a == b }
+            if (this.type != other.type) return false
+
+            // The effective prefix length ignores trailing wildcard elements,
+            // because a trailing wildcard means "any element inside this array"
+            // and the credential may store the array as a single leaf claim.
+            val effectiveSize =
+                this.value.indexOfLast { it !is ClaimPathElement.AllArrayElements } + 1
+            if (effectiveSize > other.value.size) return false
+
+            val compareSize = minOf(this.value.size, other.value.size)
+            return this.value.take(compareSize).zip(other.value.take(compareSize))
+                .all { (a, b) -> a in b || b in a }
         }
     }
 
     val joined: String
-        get() = value.joinToString(PATH_SEPARATOR)
+        get() = value.joinToString(PATH_SEPARATOR) { it.toString() }
 
     fun toId(docId: String): String {
         val namespaceOrNull: String? = when (type) {
@@ -97,7 +111,7 @@ data class ClaimPathDomain(
             namespaceOrNull?.let { safeNamespace ->
                 add(safeNamespace)
             }
-            addAll(value)
+            addAll(value.map { it.toString() })
         }.joinToString(separator = PATH_SEPARATOR)
 
         return finalId

--- a/core-logic/src/test/java/eu/europa/ec/corelogic/model/TestClaimPath.kt
+++ b/core-logic/src/test/java/eu/europa/ec/corelogic/model/TestClaimPath.kt
@@ -19,6 +19,8 @@ package eu.europa.ec.corelogic.model
 import eu.europa.ec.corelogic.extension.toClaimPath
 import eu.europa.ec.corelogic.model.ClaimPathDomain.Companion.isPrefixOf
 import eu.europa.ec.eudi.iso18013.transfer.response.device.MsoMdocItem
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPath
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
 import eu.europa.ec.eudi.wallet.transfer.openId4vp.SdJwtVcItem
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -26,17 +28,25 @@ import org.junit.Test
 
 class TestClaimPath {
 
+    /** Helper: create a SdJwtVcItem with Claim path elements from strings. */
+    private fun sdJwtVc(vararg names: String) =
+        SdJwtVcItem(ClaimPath(names.map { ClaimPathElement.Claim(it) })).toClaimPath()
+
+    /** Helper: create a SdJwtVcItem with mixed ClaimPathElements. */
+    private fun sdJwtVcPath(vararg elements: ClaimPathElement) =
+        SdJwtVcItem(ClaimPath(elements.toList())).toClaimPath()
+
     @Test
     fun `SdJwt - prefix match with deeper nesting`() {
-        val requested1 = SdJwtVcItem(listOf("address")).toClaimPath()
-        val requested2 = SdJwtVcItem(listOf("address", "formatted")).toClaimPath()
+        val requested1 = sdJwtVc("address")
+        val requested2 = sdJwtVc("address", "formatted")
 
-        val available1 = SdJwtVcItem(listOf("address", "country")).toClaimPath()
-        val available2 = SdJwtVcItem(listOf("address", "street")).toClaimPath()
-        val available3 = SdJwtVcItem(listOf("address", "street", "number")).toClaimPath()
-        val available4 = SdJwtVcItem(listOf("addressA", "street")).toClaimPath()
-        val available5 = SdJwtVcItem(listOf("addres", "street")).toClaimPath()
-        val available6 = SdJwtVcItem(listOf("address", "formattedNo")).toClaimPath()
+        val available1 = sdJwtVc("address", "country")
+        val available2 = sdJwtVc("address", "street")
+        val available3 = sdJwtVc("address", "street", "number")
+        val available4 = sdJwtVc("addressA", "street")
+        val available5 = sdJwtVc("addres", "street")
+        val available6 = sdJwtVc("address", "formattedNo")
 
         assertTrue(requested1.isPrefixOf(available1))
         assertTrue(requested1.isPrefixOf(available2))
@@ -48,11 +58,11 @@ class TestClaimPath {
 
     @Test
     fun `SdJwt - exact match returns true`() {
-        val requested1 = SdJwtVcItem(listOf("family_name")).toClaimPath()
-        val requested2 = SdJwtVcItem(listOf("family_name", "birth")).toClaimPath()
+        val requested1 = sdJwtVc("family_name")
+        val requested2 = sdJwtVc("family_name", "birth")
 
-        val available1 = SdJwtVcItem(listOf("family_name")).toClaimPath()
-        val available2 = SdJwtVcItem(listOf("family_name", "birth")).toClaimPath()
+        val available1 = sdJwtVc("family_name")
+        val available2 = sdJwtVc("family_name", "birth")
 
         assertTrue(requested1.isPrefixOf(available1))
         assertTrue(requested1.isPrefixOf(available2))
@@ -62,11 +72,11 @@ class TestClaimPath {
 
     @Test
     fun `SdJwt - non-prefix should return false`() {
-        val requested1 = SdJwtVcItem(listOf("family_name")).toClaimPath()
-        val requested2 = SdJwtVcItem(listOf("family_name_birth")).toClaimPath()
+        val requested1 = sdJwtVc("family_name")
+        val requested2 = sdJwtVc("family_name_birth")
 
-        val available1 = SdJwtVcItem(listOf("family_name_birth")).toClaimPath()
-        val available2 = SdJwtVcItem(listOf("family_name")).toClaimPath()
+        val available1 = sdJwtVc("family_name_birth")
+        val available2 = sdJwtVc("family_name")
 
         assertFalse(requested1.isPrefixOf(available1))
         assertFalse(requested2.isPrefixOf(available2))
@@ -74,12 +84,11 @@ class TestClaimPath {
 
     @Test
     fun `SdJwt - partial match but diverges deeper`() {
-        val requested = SdJwtVcItem(listOf("claim1", "claim1_a", "claim1_b")).toClaimPath()
+        val requested = sdJwtVc("claim1", "claim1_a", "claim1_b")
 
-        val match1 = SdJwtVcItem(listOf("claim1", "claim1_a", "claim1_b", "claim1_c")).toClaimPath()
-        val match2 = SdJwtVcItem(listOf("claim1", "claim1_a", "claim1_b", "claim2_c")).toClaimPath()
-        val nonMatch =
-            SdJwtVcItem(listOf("claim1", "claim1_a", "claim33_b", "claim2_c")).toClaimPath()
+        val match1 = sdJwtVc("claim1", "claim1_a", "claim1_b", "claim1_c")
+        val match2 = sdJwtVc("claim1", "claim1_a", "claim1_b", "claim2_c")
+        val nonMatch = sdJwtVc("claim1", "claim1_a", "claim33_b", "claim2_c")
 
         assertTrue(requested.isPrefixOf(match1))
         assertTrue(requested.isPrefixOf(match2))
@@ -88,16 +97,16 @@ class TestClaimPath {
 
     @Test
     fun `SdJwt - requested path longer than available returns false`() {
-        val requested = SdJwtVcItem(listOf("a", "b", "c")).toClaimPath()
-        val available = SdJwtVcItem(listOf("a", "b")).toClaimPath()
+        val requested = sdJwtVc("a", "b", "c")
+        val available = sdJwtVc("a", "b")
 
         assertFalse(requested.isPrefixOf(available))
     }
 
     @Test
     fun `SdJwt - empty requested path is prefix of any`() {
-        val requested = SdJwtVcItem(emptyList()).toClaimPath()
-        val available = SdJwtVcItem(listOf("anything", "deep")).toClaimPath()
+        val requested = SdJwtVcItem(ClaimPath(emptyList())).toClaimPath()
+        val available = sdJwtVc("anything", "deep")
 
         assertTrue(requested.isPrefixOf(available))
     }
@@ -144,9 +153,78 @@ class TestClaimPath {
     fun `MsoMdoc - namespace as prefix of sdjwt path`() {
         val msoClaimPath =
             MsoMdocItem(namespace = "address", elementIdentifier = "city").toClaimPath()
-        val sdjwtClaimPath = SdJwtVcItem(listOf("address", "city")).toClaimPath()
+        val sdjwtClaimPath = sdJwtVc("address", "city")
 
         assertFalse(msoClaimPath.isPrefixOf(sdjwtClaimPath))
         assertFalse(sdjwtClaimPath.isPrefixOf(msoClaimPath))
+    }
+
+    @Test
+    fun `SdJwt - trailing null wildcard matches array leaf claim`() {
+        val requested = sdJwtVcPath(
+            ClaimPathElement.Claim("nationality"),
+            ClaimPathElement.AllArrayElements
+        )
+        val available = sdJwtVc("nationality")
+
+        assertTrue(requested.isPrefixOf(available))
+    }
+
+    @Test
+    fun `SdJwt - null wildcard in middle matches any array index`() {
+        val requested = sdJwtVcPath(
+            ClaimPathElement.Claim("addresses"),
+            ClaimPathElement.AllArrayElements,
+            ClaimPathElement.Claim("city")
+        )
+
+        val match1 = sdJwtVcPath(
+            ClaimPathElement.Claim("addresses"),
+            ClaimPathElement.ArrayElement(0),
+            ClaimPathElement.Claim("city")
+        )
+        val match2 = sdJwtVcPath(
+            ClaimPathElement.Claim("addresses"),
+            ClaimPathElement.ArrayElement(1),
+            ClaimPathElement.Claim("city")
+        )
+        val nonMatch = sdJwtVcPath(
+            ClaimPathElement.Claim("addresses"),
+            ClaimPathElement.ArrayElement(0),
+            ClaimPathElement.Claim("street")
+        )
+
+        assertTrue(requested.isPrefixOf(match1))
+        assertTrue(requested.isPrefixOf(match2))
+        assertFalse(requested.isPrefixOf(nonMatch))
+    }
+
+    @Test
+    fun `SdJwt - null wildcard as prefix matches deeper nested paths`() {
+        val requested = sdJwtVcPath(
+            ClaimPathElement.Claim("addresses"),
+            ClaimPathElement.AllArrayElements
+        )
+
+        val match1 = sdJwtVcPath(
+            ClaimPathElement.Claim("addresses"),
+            ClaimPathElement.ArrayElement(0),
+            ClaimPathElement.Claim("city")
+        )
+        val match2 = sdJwtVc("addresses")
+
+        assertTrue(requested.isPrefixOf(match1))
+        assertTrue(requested.isPrefixOf(match2))
+    }
+
+    @Test
+    fun `SdJwt - non-matching claim with null wildcard`() {
+        val requested = sdJwtVcPath(
+            ClaimPathElement.Claim("nationality"),
+            ClaimPathElement.AllArrayElements
+        )
+        val available = sdJwtVc("family_name")
+
+        assertFalse(requested.isPrefixOf(available))
     }
 }

--- a/core-logic/src/test/java/eu/europa/ec/corelogic/model/TestClaimPath.kt
+++ b/core-logic/src/test/java/eu/europa/ec/corelogic/model/TestClaimPath.kt
@@ -28,13 +28,19 @@ import org.junit.Test
 
 class TestClaimPath {
 
-    /** Helper: create a SdJwtVcItem with Claim path elements from strings. */
+    /** Helper: create a ClaimPathDomain for SD-JWT VC from claim name strings. */
     private fun sdJwtVc(vararg names: String) =
-        SdJwtVcItem(ClaimPath(names.map { ClaimPathElement.Claim(it) })).toClaimPath()
+        ClaimPathDomain(
+            value = names.map { ClaimPathElement.Claim(it) },
+            type = ClaimType.SdJwtVc
+        )
 
-    /** Helper: create a SdJwtVcItem with mixed ClaimPathElements. */
+    /** Helper: create a ClaimPathDomain for SD-JWT VC from mixed ClaimPathElements. */
     private fun sdJwtVcPath(vararg elements: ClaimPathElement) =
-        SdJwtVcItem(ClaimPath(elements.toList())).toClaimPath()
+        ClaimPathDomain(
+            value = elements.toList(),
+            type = ClaimType.SdJwtVc
+        )
 
     @Test
     fun `SdJwt - prefix match with deeper nesting`() {
@@ -105,7 +111,7 @@ class TestClaimPath {
 
     @Test
     fun `SdJwt - empty requested path is prefix of any`() {
-        val requested = SdJwtVcItem(ClaimPath(emptyList())).toClaimPath()
+        val requested = ClaimPathDomain(value = emptyList(), type = ClaimType.SdJwtVc)
         val available = sdJwtVc("anything", "deep")
 
         assertTrue(requested.isPrefixOf(available))

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestDocumentDetailsInteractor.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestDocumentDetailsInteractor.kt
@@ -24,6 +24,7 @@ import eu.europa.ec.corelogic.controller.WalletCoreDocumentsController
 import eu.europa.ec.corelogic.model.ClaimDomain
 import eu.europa.ec.corelogic.model.ClaimPathDomain
 import eu.europa.ec.corelogic.model.ClaimType
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
 import eu.europa.ec.corelogic.model.DocumentIdentifier
 import eu.europa.ec.dashboardfeature.ui.documents.detail.model.DocumentDetailsDomain
 import eu.europa.ec.dashboardfeature.ui.documents.model.DocumentCredentialsInfoUi
@@ -405,7 +406,7 @@ class TestDocumentDetailsInteractor {
                                     value = "0",
                                     displayTitle = "no_data_item",
                                     path = ClaimPathDomain(
-                                        value = listOf("no_data_item"),
+                                        value = listOf(ClaimPathElement.Claim("no_data_item")),
                                         type = ClaimType.MsoMdoc(namespace = mockedMdocPidNameSpace)
                                     ),
                                     isRequired = false,

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/util/TestData.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/util/TestData.kt
@@ -20,6 +20,7 @@ import eu.europa.ec.corelogic.model.ClaimDomain
 import eu.europa.ec.corelogic.model.ClaimPathDomain
 import eu.europa.ec.corelogic.model.ClaimType
 import eu.europa.ec.corelogic.model.DocumentIdentifier
+import eu.europa.ec.eudi.openid4vp.dcql.ClaimPathElement
 import eu.europa.ec.dashboardfeature.ui.documents.detail.model.DocumentDetailsDomain
 import eu.europa.ec.dashboardfeature.ui.documents.detail.model.DocumentDetailsUi
 import eu.europa.ec.dashboardfeature.ui.documents.detail.model.DocumentIssuanceStateUi
@@ -68,7 +69,7 @@ internal val mockedBasicPidDomain = DocumentDetailsDomain(
             value = "ANDERSSON",
             displayTitle = "family_name",
             path = ClaimPathDomain(
-                value = listOf("family_name"),
+                value = listOf(ClaimPathElement.Claim("family_name")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocPidNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -78,7 +79,7 @@ internal val mockedBasicPidDomain = DocumentDetailsDomain(
             value = "JAN",
             displayTitle = "given_name",
             path = ClaimPathDomain(
-                value = listOf("given_name"),
+                value = listOf(ClaimPathElement.Claim("given_name")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocPidNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -88,7 +89,7 @@ internal val mockedBasicPidDomain = DocumentDetailsDomain(
             value = "yes",
             displayTitle = "age_over_18",
             path = ClaimPathDomain(
-                value = listOf("age_over_18"),
+                value = listOf(ClaimPathElement.Claim("age_over_18")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocPidNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -98,7 +99,7 @@ internal val mockedBasicPidDomain = DocumentDetailsDomain(
             value = "no",
             displayTitle = "age_over_65",
             path = ClaimPathDomain(
-                value = listOf("age_over_65"),
+                value = listOf(ClaimPathElement.Claim("age_over_65")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocPidNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -108,7 +109,7 @@ internal val mockedBasicPidDomain = DocumentDetailsDomain(
             value = "1985",
             displayTitle = "age_birth_year",
             path = ClaimPathDomain(
-                value = listOf("age_birth_year"),
+                value = listOf(ClaimPathElement.Claim("age_birth_year")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocPidNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -118,7 +119,7 @@ internal val mockedBasicPidDomain = DocumentDetailsDomain(
             value = "KATRINEHOLM",
             displayTitle = "birth_city",
             path = ClaimPathDomain(
-                value = listOf("birth_city"),
+                value = listOf(ClaimPathElement.Claim("birth_city")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocPidNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -128,7 +129,7 @@ internal val mockedBasicPidDomain = DocumentDetailsDomain(
             value = "Male",
             displayTitle = "gender",
             path = ClaimPathDomain(
-                value = listOf("gender"),
+                value = listOf(ClaimPathElement.Claim("gender")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocPidNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -138,7 +139,7 @@ internal val mockedBasicPidDomain = DocumentDetailsDomain(
             value = "30 Mar 2050",
             displayTitle = "expiry_date",
             path = ClaimPathDomain(
-                value = listOf("expiry_date"),
+                value = listOf(ClaimPathElement.Claim("expiry_date")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocPidNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -226,7 +227,7 @@ internal val mockedBasicMdlDomain = DocumentDetailsDomain(
             value = "ANDERSSON",
             displayTitle = "family_name",
             path = ClaimPathDomain(
-                value = listOf("family_name"),
+                value = listOf(ClaimPathElement.Claim("family_name")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocMdlNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -236,7 +237,7 @@ internal val mockedBasicMdlDomain = DocumentDetailsDomain(
             value = "JAN",
             displayTitle = "given_name",
             path = ClaimPathDomain(
-                value = listOf("given_name"),
+                value = listOf(ClaimPathElement.Claim("given_name")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocMdlNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -246,7 +247,7 @@ internal val mockedBasicMdlDomain = DocumentDetailsDomain(
             value = "SWEDEN",
             displayTitle = "birth_place",
             path = ClaimPathDomain(
-                value = listOf("birth_place"),
+                value = listOf(ClaimPathElement.Claim("birth_place")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocMdlNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -256,7 +257,7 @@ internal val mockedBasicMdlDomain = DocumentDetailsDomain(
             value = "30 Mar 2050",
             displayTitle = "expiry_date",
             path = ClaimPathDomain(
-                value = listOf("expiry_date"),
+                value = listOf(ClaimPathElement.Claim("expiry_date")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocMdlNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -266,7 +267,7 @@ internal val mockedBasicMdlDomain = DocumentDetailsDomain(
             value = "SE",
             displayTitle = "portrait",
             path = ClaimPathDomain(
-                value = listOf("portrait"),
+                value = listOf(ClaimPathElement.Claim("portrait")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocMdlNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -276,7 +277,7 @@ internal val mockedBasicMdlDomain = DocumentDetailsDomain(
             value = "SE",
             displayTitle = "signature_usual_mark",
             path = ClaimPathDomain(
-                value = listOf("signature_usual_mark"),
+                value = listOf(ClaimPathElement.Claim("signature_usual_mark")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocMdlNameSpace)
             ),
             isRequired = mockedClaimIsRequired
@@ -286,7 +287,7 @@ internal val mockedBasicMdlDomain = DocumentDetailsDomain(
             value = "Male",
             displayTitle = "sex",
             path = ClaimPathDomain(
-                value = listOf("sex"),
+                value = listOf(ClaimPathElement.Claim("sex")),
                 type = ClaimType.MsoMdoc(namespace = mockedMdocMdlNameSpace)
             ),
             isRequired = mockedClaimIsRequired


### PR DESCRIPTION
## Description

  Adapt app domain layer to use typed `ClaimPathElement` from openid4vp library, replacing `List<String>` with `List<ClaimPathElement>` in `ClaimPathDomain`. This enables proper DCQL
  wildcard matching for queries like `{path: ["nationality", null], values: ["NL"]}`.

  ### Key changes:
  - `ClaimPathDomain.value`: `List<String>` → `List<ClaimPathElement>`
  - `isPrefixOf()`: supports `AllArrayElements` wildcard with trailing tolerance
  - All path construction/consumption sites adapted to use `ClaimPathElement.Claim`

  ### Dependencies:
  - `eudi-lib-android-wallet-core` with typed `SdJwtVcItem.path: ClaimPath`
  - `eudi-lib-jvm-openid4vp-kt` with relaxed MsoMdoc path validation

  ## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Other fix (maintenance or house-keeping)

  # How Has This Been Tested?

  - [x] Test suite run successfully
  - [x] Added Tests (wildcard prefix matching: trailing null, middle null, array index)

  End-to-end DCQL null array matching verified on device with both dev and demo builds.

  # Checklist:

  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the readme
  - [x] My changes generate no new warnings
  - [x] I have added unit tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have checked that my views are *accessible*
  - [x] I have checked that my strings are *localized* where applicable