### PR TITLE
fix: ensure presentation scopes are closed during cleanup

### DIFF
--- a/presentation-feature/src/main/java/eu/europa/ec/presentationfeature/ui/loading/PresentationLoadingViewModel.kt
+++ b/presentation-feature/src/main/java/eu/europa/ec/presentationfeature/ui/loading/PresentationLoadingViewModel.kt
@@ -67,7 +67,9 @@ class PresentationLoadingViewModel(
     private fun getNextScreen(): String {
         return generateComposableNavigationLink(
             screen = PresentationScreens.PresentationSuccess,
-            arguments = generateComposableArguments(mapOf("scopeId" to presentationScopeId))
+            arguments = generateComposableArguments(
+                mapOf("scopeId" to presentationScopeId)
+            )
         )
     }
 
@@ -75,7 +77,9 @@ class PresentationLoadingViewModel(
 
     override fun doWork(context: Context) {
         viewModelScope.launch {
+
             interactor.setScopeId(presentationScopeId)
+
             interactor.observeResponse().collect {
                 when (it) {
                     is PresentationLoadingObserveResponsePartialState.Failure -> {

--- a/presentation-feature/src/main/java/eu/europa/ec/presentationfeature/ui/request/PresentationRequestViewModel.kt
+++ b/presentation-feature/src/main/java/eu/europa/ec/presentationfeature/ui/request/PresentationRequestViewModel.kt
@@ -188,7 +188,7 @@ class PresentationRequestViewModel(
     override fun cleanUp() {
         super.cleanUp()
         interactor.stopPresentation()
-        getOrCreatePresentationScope(viewState.value.presentationScopeId)
+        getOrCreatePresentationScope(viewState.value.presentationScopeId).close()
     }
 
     private fun getRelyingPartyData(

--- a/presentation-feature/src/main/java/eu/europa/ec/presentationfeature/ui/success/PresentationSuccessViewModel.kt
+++ b/presentation-feature/src/main/java/eu/europa/ec/presentationfeature/ui/success/PresentationSuccessViewModel.kt
@@ -51,7 +51,9 @@ class PresentationSuccessViewModel(
         }
 
         viewModelScope.launch {
+
             interactor.setScopeId(presentationScopeId)
+
             interactor.getUiItems().collect { response ->
                 when (response) {
                     is PresentationSuccessInteractorGetUiItemsPartialState.Failed -> {

--- a/proximity-feature/src/main/java/eu/europa/ec/proximityfeature/ui/loading/ProximityLoadingViewModel.kt
+++ b/proximity-feature/src/main/java/eu/europa/ec/proximityfeature/ui/loading/ProximityLoadingViewModel.kt
@@ -66,7 +66,7 @@ class ProximityLoadingViewModel(
 
     private fun getNextScreen(): String {
         return generateComposableNavigationLink(
-            screen = ProximityScreens.Success.screenRoute,
+            screen = ProximityScreens.Success,
             arguments = generateComposableArguments(
                 mapOf("scopeId" to presentationScopeId)
             )

--- a/proximity-feature/src/main/java/eu/europa/ec/proximityfeature/ui/qr/ProximityQRViewModel.kt
+++ b/proximity-feature/src/main/java/eu/europa/ec/proximityfeature/ui/qr/ProximityQRViewModel.kt
@@ -181,7 +181,7 @@ class ProximityQRViewModel(
      * */
     private fun cleanUp() {
         unsubscribe()
-        getOrCreatePresentationScope(viewState.value.presentationScopeId).close()
         interactor.cancelTransfer()
+        getOrCreatePresentationScope(viewState.value.presentationScopeId).close()
     }
 }

--- a/proximity-feature/src/main/java/eu/europa/ec/proximityfeature/ui/request/ProximityRequestViewModel.kt
+++ b/proximity-feature/src/main/java/eu/europa/ec/proximityfeature/ui/request/ProximityRequestViewModel.kt
@@ -182,7 +182,7 @@ class ProximityRequestViewModel(
     override fun cleanUp() {
         super.cleanUp()
         interactor.stopPresentation()
-        getOrCreatePresentationScope(presentationScopeId)
+        getOrCreatePresentationScope(presentationScopeId).close()
     }
 
     private fun getRelyingPartyData(


### PR DESCRIPTION
This commit ensures that `presentationScope` is correctly closed in various view models within the presentation and proximity features to prevent potential resource leaks. It also includes minor refactoring of navigation calls and cleanup sequences.

Key changes include:
- Added missing `.close()` calls to the result of `getOrCreatePresentationScope()` in `PresentationRequestViewModel` and `ProximityRequestViewModel`.
- Reordered the `cleanUp()` logic in `ProximityQRViewModel` to ensure the interactor cancels the transfer before the presentation scope is closed.
- Updated `ProximityLoadingViewModel` to pass the `ProximityScreens.Success` object directly to `generateComposableNavigationLink` instead of its `screenRoute` property.
- Applied minor code formatting and whitespace adjustments in `PresentationLoadingViewModel` and `PresentationSuccessViewModel` for better readability.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable