### PR TITLE
refactor: generalize portrait check to user image and add picture key

### DIFF
--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/extension/DomainClaimExtensions.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/extension/DomainClaimExtensions.kt
@@ -17,8 +17,8 @@
 package eu.europa.ec.commonfeature.extension
 
 import eu.europa.ec.commonfeature.ui.request.model.DocumentPayloadDomain
-import eu.europa.ec.commonfeature.util.keyIsPortrait
 import eu.europa.ec.commonfeature.util.keyIsSignature
+import eu.europa.ec.commonfeature.util.keyIsUserImage
 import eu.europa.ec.corelogic.model.ClaimDomain
 import eu.europa.ec.eudi.wallet.document.ElementIdentifier
 import eu.europa.ec.uilogic.component.AppIcons
@@ -102,7 +102,7 @@ private fun calculateMainContent(
     value: String,
 ): ListItemMainContentDataUi {
     return when {
-        keyIsPortrait(key = key) -> {
+        keyIsUserImage(key = key) -> {
             ListItemMainContentDataUi.Text(text = "")
         }
 
@@ -120,7 +120,7 @@ private fun calculateLeadingContent(
     key: ElementIdentifier,
     value: String,
 ): ListItemLeadingContentDataUi? {
-    return if (keyIsPortrait(key = key)) {
+    return if (keyIsUserImage(key = key)) {
         ListItemLeadingContentDataUi.UserImage(userBase64Image = value)
     } else {
         null

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentHelper.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentHelper.kt
@@ -52,8 +52,9 @@ fun extractValueFromDocumentOrEmpty(
         ?: ""
 }
 
-fun keyIsPortrait(key: String): Boolean {
-    return key == DocumentJsonKeys.PORTRAIT
+fun keyIsUserImage(key: String): Boolean {
+    val listOfUserImageKeys = DocumentJsonKeys.BASE64_USER_IMAGE_KEYS
+    return listOfUserImageKeys.contains(key)
 }
 
 fun keyIsSignature(key: String): Boolean {

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentJsonKeys.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/util/DocumentJsonKeys.kt
@@ -20,6 +20,7 @@ object DocumentJsonKeys {
     const val FIRST_NAME = "given_name"
     const val LAST_NAME = "family_name"
     const val PORTRAIT = "portrait"
+    const val PICTURE = "picture"
     const val SIGNATURE = "signature_usual_mark"
     const val EXPIRY_DATE = "expiry_date"
     const val USER_PSEUDONYM = "user_pseudonym"
@@ -27,5 +28,5 @@ object DocumentJsonKeys {
     private const val SEX = "sex"
 
     val GENDER_KEYS: List<String> = listOf(GENDER, SEX)
-    val BASE64_IMAGE_KEYS: List<String> = listOf(PORTRAIT, SIGNATURE)
+    val BASE64_USER_IMAGE_KEYS: List<String> = listOf(PORTRAIT, PICTURE)
 }


### PR DESCRIPTION
This commit refactors the document utility logic to support multiple user image identifiers. It renames portrait-specific functions and constants to a more general "user image" naming convention and adds support for the "picture" key.

Key changes include:
- Renamed `keyIsPortrait` to `keyIsUserImage` in `DocumentHelper.kt` and updated it to check against a list of valid image keys.
- Added `PICTURE` key to `DocumentJsonKeys`.
- Renamed `BASE64_IMAGE_KEYS` to `BASE64_USER_IMAGE_KEYS` in `DocumentJsonKeys`, including both `PORTRAIT` and `PICTURE` while removing `SIGNATURE`.
- Updated `DomainClaimExtensions.kt` to use the new `keyIsUserImage` helper for UI rendering logic.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable