### PR TITLE
refactor: migrate SharedPreferences to encrypted DataStore

### DIFF
--- a/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/storage/PrefsPinStorageProvider.kt
+++ b/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/storage/PrefsPinStorageProvider.kt
@@ -32,14 +32,13 @@ class PrefsPinStorageProvider(
 ) : PinStorageProvider {
 
     private companion object {
-        private const val KEY_PIN_SALT = "PinSalt"
-        private const val KEY_PIN_HASH = "PinHash"
-        private const val KEY_PIN_ITERATIONS = "PinIterations"
-
-        private const val SALT_SIZE_BYTES = 32
-        private const val HASH_SIZE_BITS = 256
-        private const val DEFAULT_ITERATIONS = 210_000
-        private const val ALGORITHM = "PBKDF2WithHmacSHA256"
+        const val KEY_PIN_SALT = "PinSalt"
+        const val KEY_PIN_HASH = "PinHash"
+        const val KEY_PIN_ITERATIONS = "PinIterations"
+        const val SALT_SIZE_BYTES = 32
+        const val HASH_SIZE_BITS = 256
+        const val DEFAULT_ITERATIONS = 210_000
+        const val ALGORITHM = "PBKDF2WithHmacSHA256"
     }
 
     /**

--- a/business-logic/build.gradle.kts
+++ b/business-logic/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation(libs.google.phonenumber)
     implementation(libs.timber)
     implementation(libs.treessence)
+    implementation(libs.androidx.datastore.prefs)
+    implementation(libs.androidx.datastore.core)
+    implementation(libs.androidx.datastore.tink)
 
     testImplementation(project(LibraryModule.TestLogic.path))
     androidTestImplementation(project(LibraryModule.TestLogic.path))

--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/crypto/KeystoreController.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/crypto/KeystoreController.kt
@@ -36,8 +36,8 @@ class KeystoreControllerImpl(
     private val uuidProvider: UuidProvider
 ) : KeystoreController {
 
-    companion object {
-        private const val STORE_TYPE = "AndroidKeyStore"
+    private companion object {
+        const val STORE_TYPE = "AndroidKeyStore"
     }
 
     private var androidKeyStore: KeyStore? = null

--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/storage/PrefsController.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/storage/PrefsController.kt
@@ -16,293 +16,170 @@
 
 package eu.europa.ec.businesslogic.controller.storage
 
-import android.content.Context.MODE_PRIVATE
-import android.content.SharedPreferences
-import androidx.core.content.edit
-import eu.europa.ec.businesslogic.extension.shuffle
-import eu.europa.ec.businesslogic.extension.unShuffle
+import android.content.Context
+import android.util.Base64
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferencesFileSerializer
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.datastore.tink.AeadSerializer
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.RegistryConfiguration
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.integration.android.AndroidKeysetManager
+import eu.europa.ec.businesslogic.extension.decodeFromBase64
+import eu.europa.ec.businesslogic.extension.encodeToBase64String
 import eu.europa.ec.resourceslogic.provider.ResourceProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 
 interface PrefsController {
-
-    /**
-     * Defines if [SharedPreferences] contains a value for given [key]. This function will only
-     * identify if a key exists in storage and will not check if corresponding value is valid.
-     *
-     * @param key The name of the preference to check.
-     *
-     * @return `true` if preferences contain given key. `false` otherwise.
-     */
     fun contains(key: String): Boolean
-
-    /**
-     * Removes given preference key from shared preferences. Notice that this operation is
-     * irreversible and may lead to data loss.
-     */
     fun clear(key: String)
-
-    /**
-     * Removes all keys from shared preferences. Notice that this operation is
-     * irreversible and may lead to data loss.
-     */
     fun clear()
-
-    /**
-     * Assigns given [value] to device storage - shared preferences given [key]. You can
-     * retrieve this value by calling [getString].
-     *
-     * @param key   Key used to add given [value].
-     * @param value Value to add after given [key].
-     */
     fun setString(key: String, value: String)
-
-    /**
-     * Assigns given [value] to device storage - shared preferences given [key]. You can
-     * retrieve this value by calling [getString].
-     *
-     * @param key   Key used to add given [value].
-     * @param value Value to add after given [key].
-     */
-    fun setLong(
-        key: String, value: Long
-    )
-
-    /**
-     * Assigns given [value] to device storage - shared preferences given [key]. You can
-     * retrieve this value by calling [getString].
-     *
-     * @param key   Key used to add given [value].
-     * @param value Value to add after given [key].
-     */
+    fun setLong(key: String, value: Long)
     fun setBool(key: String, value: Boolean)
-
-    /**
-     * Retrieves a string value from device shared preferences that corresponds to given [key]. If
-     * key does not exist or value of given key is null, [defaultValue] is returned.
-     *
-     * @param key          Key to get corresponding value.
-     * @param defaultValue Default value to return if given [key] does not exist in prefs or if
-     * key value is invalid.
-     */
     fun getString(key: String, defaultValue: String): String
-
-    /**
-     * Retrieves a long value from device shared preferences that corresponds to given [key]. If
-     * key does not exist or value of given key is null, [defaultValue] is returned.
-     *
-     * @param key          Key to get corresponding value.
-     * @param defaultValue Default value to return if given [key] does not exist in prefs or if
-     * key value is invalid.
-     */
     fun getLong(key: String, defaultValue: Long): Long
-
-    /**
-     * Retrieves a boolean value from the device's shared preferences associated with the given [key].
-     *
-     * If the [key] is not found in the preferences, or if the value associated with the [key] is null,
-     * the [defaultValue] is returned.  Note that if a value exists for the key but is not a valid
-     * boolean (e.g., a String or an Int), the platform may also return the [defaultValue], depending on
-     * the underlying shared preferences implementation.
-     *
-     * @param key The key used to retrieve the boolean value.
-     * @param defaultValue The boolean value to return if the [key] is not found or has a null value.
-     * @return The boolean value associated with the [key], or the [defaultValue] if the [key] is not found or has a null value.
-     */
     fun getBool(key: String, defaultValue: Boolean): Boolean
-
-    /**
-     * Sets an integer value associated with the given key in the underlying data store.
-     * If a value already exists for the key, it will be overwritten.
-     *
-     * @param key The unique identifier for the integer value.  Must not be null or empty.
-     * @param value The integer value to store.
-     */
     fun setInt(key: String, value: Int)
-
-    /**
-     * Retrieves an integer value associated with the given key from a data source.
-     * If the key is not found or the value is not an integer, it returns the specified default value.
-     *
-     * @param key The key associated with the integer value to retrieve.
-     * @param defaultValue The default integer value to return if the key is not found or the value is not an integer.
-     * @return The integer value associated with the key, or the default value if the key is not found or the value is invalid.
-     */
     fun getInt(key: String, defaultValue: Int): Int
 }
 
 /**
- * Implementation of the [PrefsController] interface for managing application preferences.
+ * Implementation of [PrefsController] that provides a secure, encrypted key-value storage
+ * using Jetpack DataStore and Google Tink for Authenticated Encryption with Associated Data (AEAD).
  *
- * This class provides methods for storing and retrieving various data types (String, Long, Boolean, Int)
- * in the application's SharedPreferences.  All SharedPreferences are
- * stored within a file named "eudi-wallet" accessible only to this application.
+ * This class handles the persistence of primitive types (String, Long, Boolean, Int) and ensures
+ * that the underlying data is encrypted at rest using a master key stored in the Android Keystore.
  *
- * @property resourceProvider An instance of [ResourceProvider] used to access application resources,
- *                           including the application context for obtaining SharedPreferences.
+ * All operations are performed synchronously using [runBlocking] on [Dispatchers.IO] to maintain
+ * compatibility.
+ *
+ * @property resourceProvider An instance of [ResourceProvider] used to access the application context.
  */
 class PrefsControllerImpl(
     private val resourceProvider: ResourceProvider
 ) : PrefsController {
 
-
-    /**
-     * Retrieves the SharedPreferences instance for the application.
-     *
-     * This function provides access to the SharedPreferences object used by the application
-     * for persistent storage of key-value pairs. The SharedPreferences are named "eudi-wallet"
-     * and are accessed with private mode, meaning only this application can read or write to them.
-     *
-     * @return The SharedPreferences instance.
-     */
-    private fun getSharedPrefs(): SharedPreferences {
-        return resourceProvider.provideContext().getSharedPreferences("eudi-wallet", MODE_PRIVATE)
+    private companion object {
+        const val DATASTORE_FILE = "eudi-wallet.preferences_pb"
+        const val KEYSET_PREFS_FILE = "eudi-wallet-datastore-keyset"
+        const val KEYSET_PREFS_KEY = "prefs_datastore_keyset"
+        const val MASTER_KEY_URI = "android-keystore://eudi-wallet-datastore-master-key"
     }
 
-    /**
-     * Defines if [SharedPreferences] contains a value for given [key]. This function will only
-     * identify if a key exists in storage and will not check if corresponding value is valid.
-     *
-     * @param key The name of the preference to check.
-     *
-     * @return `true` if preferences contain given key. `false` otherwise.
-     */
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val dataStore: DataStore<Preferences> by lazy {
+        val context = resourceProvider.provideContext().applicationContext
+        DataStoreFactory.create(
+            serializer = AeadSerializer(
+                aead = provideAead(context),
+                wrappedSerializer = PreferencesFileSerializer,
+                associatedData = DATASTORE_FILE.toByteArray(Charsets.UTF_8)
+            ),
+            scope = scope,
+            produceFile = { context.preferencesDataStoreFile(DATASTORE_FILE) }
+        )
+    }
+
     override fun contains(key: String): Boolean {
-        return getSharedPrefs().contains(key)
+        val prefs = read()
+        return prefs.asMap().keys.any { it.name == key }
     }
 
-    /**
-     * Removes given preference key from shared preferences. Notice that this operation is
-     * irreversible and may lead to data loss.
-     */
     override fun clear(key: String) {
-        getSharedPrefs().edit { remove(key) }
+        edit { prefs ->
+            prefs.remove(stringPreferencesKey(key))
+            prefs.remove(longPreferencesKey(key))
+            prefs.remove(booleanPreferencesKey(key))
+            prefs.remove(intPreferencesKey(key))
+        }
     }
 
-    /**
-     * Removes all keys from shared preferences. Notice that this operation is
-     * irreversible and may lead to data loss.
-     */
     override fun clear() {
-        getSharedPrefs().edit { clear() }
+        edit { it.clear() }
     }
 
-    /**
-     * Assigns given [value] to device storage - shared preferences given [key]. You can
-     * retrieve this value by calling [getString].
-     *
-     * Shared preferences are encrypted. Do not create your own instance to add or retrieve data.
-     * Instead, call operations of this controller.
-     *
-     * @param key   Key used to add given [value].
-     * @param value Value to add after given [key].
-     */
     override fun setString(key: String, value: String) {
-        getSharedPrefs().edit {
-            putString(key, value.shuffle())
+        edit { prefs ->
+            prefs[stringPreferencesKey(key)] = value
         }
     }
 
-    /**
-     * Assigns given [value] to device storage - shared preferences given [key]. You can
-     * retrieve this value by calling [getString].
-     *
-     * Shared preferences are encrypted. Do not create your own instance to add or retrieve data.
-     * Instead, call operations of this controller.
-     *
-     * @param key   Key used to add given [value].
-     * @param value Value to add after given [key].
-     */
-    override fun setLong(
-        key: String, value: Long
-    ) {
-        getSharedPrefs().edit {
-            putLong(key, value)
+    override fun setLong(key: String, value: Long) {
+        edit { prefs ->
+            prefs[longPreferencesKey(key)] = value
         }
     }
 
-    /**
-     * Assigns given [value] to device storage - shared preferences given [key]. You can
-     * retrieve this value by calling [getString].
-     *
-     * Shared preferences are encrypted. Do not create your own instance to add or retrieve data.
-     * Instead, call operations of this controller.
-     *
-     * @param key   Key used to add given [value].
-     * @param value Value to add after given [key].
-     */
     override fun setBool(key: String, value: Boolean) {
-        getSharedPrefs().edit {
-            putBoolean(key, value)
+        edit { prefs ->
+            prefs[booleanPreferencesKey(key)] = value
         }
     }
 
-    /**
-     * Retrieves a string value from device shared preferences that corresponds to given [key]. If
-     * key does not exist or value of given key is null, [defaultValue] is returned.
-     *
-     * Shared preferences are encrypted. Do not create your own instance to add or retrieve data.
-     * Instead, call operations of this controller.
-     *
-     * @param key          Key to get corresponding value.
-     * @param defaultValue Default value to return if given [key] does not exist in prefs or if
-     * key value is invalid.
-     */
-    override fun getString(key: String, defaultValue: String): String {
-        return getSharedPrefs().getString(key, null)?.unShuffle() ?: defaultValue
-    }
-
-    /**
-     * Retrieves a long value from device shared preferences that corresponds to given [key]. If
-     * key does not exist or value of given key is null, [defaultValue] is returned.
-     *
-     * Shared preferences are encrypted. Do not create your own instance to add or retrieve data.
-     * Instead, call operations of this controller.
-     *
-     * @param key          Key to get corresponding value.
-     * @param defaultValue Default value to return if given [key] does not exist in prefs or if
-     * key value is invalid.
-     */
-    override fun getLong(key: String, defaultValue: Long): Long {
-        return getSharedPrefs().getLong(key, defaultValue)
-    }
-
-    /**
-     * Retrieves a boolean value from device shared preferences that corresponds to given [key]. If
-     * key does not exist or value of given key is null, [defaultValue] is returned.
-     *
-     * Shared preferences are encrypted. Do not create your own instance to add or retrieve data.
-     * Instead, call operations of this controller.
-     *
-     * @param key          Key to get corresponding value.
-     * @param defaultValue Default value to return if given [key] does not exist in prefs or if
-     * key value is invalid.
-     */
-    override fun getBool(key: String, defaultValue: Boolean): Boolean {
-        return getSharedPrefs().getBoolean(key, defaultValue)
-    }
-
-    /**
-     * Retrieves an integer value from SharedPreferences associated with the given key.
-     * If no value is found for the key, returns the provided default value.
-     *
-     * @param key The key associated with the integer value to retrieve.
-     * @param defaultValue The default integer value to return if no value is found for the key.
-     * @return The integer value associated with the key, or the default value if no value is found.
-     */
-    override fun getInt(key: String, defaultValue: Int): Int {
-        return getSharedPrefs().getInt(key, defaultValue)
-    }
-
-    /**
-     * Sets an integer value in the shared preferences.
-     *
-     * @param key The key under which the value should be stored.
-     * @param value The integer value to be stored.
-     */
     override fun setInt(key: String, value: Int) {
-        getSharedPrefs().edit {
-            putInt(key, value)
+        edit { prefs ->
+            prefs[intPreferencesKey(key)] = value
         }
+    }
+
+    override fun getString(key: String, defaultValue: String): String {
+        return read()[stringPreferencesKey(key)] ?: defaultValue
+    }
+
+    override fun getLong(key: String, defaultValue: Long): Long {
+        return read()[longPreferencesKey(key)] ?: defaultValue
+    }
+
+    override fun getBool(key: String, defaultValue: Boolean): Boolean {
+        return read()[booleanPreferencesKey(key)] ?: defaultValue
+    }
+
+    override fun getInt(key: String, defaultValue: Int): Int {
+        return read()[intPreferencesKey(key)] ?: defaultValue
+    }
+
+    private fun read(): Preferences = runBlocking(Dispatchers.IO) {
+        dataStore.data.first()
+    }
+
+    private fun edit(block: suspend (MutablePreferences) -> Unit) =
+        runBlocking(Dispatchers.IO) {
+            dataStore.edit { prefs ->
+                block(prefs)
+            }
+        }
+
+    private fun provideAead(context: Context): Aead {
+
+        AeadConfig.register()
+
+        val keysetHandle = AndroidKeysetManager.Builder()
+            .withSharedPref(context, KEYSET_PREFS_KEY, KEYSET_PREFS_FILE)
+            .withKeyTemplate(KeyTemplates.get("AES256_GCM"))
+            .withMasterKeyUri(MASTER_KEY_URI)
+            .build()
+            .keysetHandle
+
+        return keysetHandle.getPrimitive(
+            RegistryConfiguration.get(),
+            Aead::class.java
+        )
     }
 }
 
@@ -311,7 +188,7 @@ interface PrefKeys {
     fun setCryptoAlias(value: String)
     fun setSessionId(value: String)
     fun getSessionId(): String
-    fun setDbKey(value: String)
+    fun setDbKey(value: ByteArray)
     fun getDbKey(): ByteArray?
 }
 
@@ -319,66 +196,29 @@ class PrefKeysImpl(
     private val prefsController: PrefsController
 ) : PrefKeys {
 
-
-    /**
-     * Retrieves the alias used for cryptographic operations from SharedPreferences.
-     * This alias is typically used to identify a specific key or set of keys
-     * stored in the Android Keystore system.
-     *
-     * @return The crypto alias string. Returns an empty string if the alias is not found
-     *         or has not been set.
-     */
     override fun getCryptoAlias(): String {
         return prefsController.getString("CryptoAlias", "")
     }
 
-    /**
-     * Stores the crypto alias used for the secret key in android keystore.
-     * This is used for cryptographic operations not related to biometrics.
-     *
-     * @param value the crypto alias value.
-     */
     override fun setCryptoAlias(value: String) {
         prefsController.setString("CryptoAlias", value)
     }
 
-    /**
-     * Stores the session identifier in the application's shared preferences.
-     * This ID is used to maintain the current session state across application launches.
-     *
-     * @param value The session identifier string to be stored.
-     */
     override fun setSessionId(value: String) {
         prefsController.setString("SessionId", value)
     }
 
-    /**
-     * Retrieves the unique session identifier from the application storage.
-     *
-     * @return The current session ID string, or an empty string if no session ID has been set.
-     */
-    override fun getSessionId(): String = prefsController.getString("SessionId", "")
-
-    /**
-     * Retrieves the database encryption key from the application storage.
-     * This key is typically used to initialize or open the encrypted local database.
-     *
-     * @return The database key as a [ByteArray], or `null` if the key has not been set.
-     */
-    override fun getDbKey(): ByteArray? {
-        val key = prefsController.getString("dbKey", "").ifEmpty {
-            null
-        }
-        return key?.toByteArray(Charsets.UTF_8)
+    override fun getSessionId(): String {
+        return prefsController.getString("SessionId", "")
     }
 
-    /**
-     * Stores the database encryption key in the application's shared preferences.
-     * This key is used to secure the local database.
-     *
-     * @param value The encryption key string to be stored.
-     */
-    override fun setDbKey(value: String) {
-        prefsController.setString("dbKey", value)
+    override fun setDbKey(value: ByteArray) {
+        val encoded = value.encodeToBase64String(flags = Base64.NO_WRAP)
+        prefsController.setString("dbKey", encoded)
+    }
+
+    override fun getDbKey(): ByteArray? {
+        val encoded = prefsController.getString("dbKey", "").ifBlank { return null }
+        return encoded.decodeFromBase64(flags = Base64.NO_WRAP)
     }
 }

--- a/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/pin/PinViewModel.kt
+++ b/common-feature/src/main/java/eu/europa/ec/commonfeature/ui/pin/PinViewModel.kt
@@ -210,6 +210,7 @@ class PinViewModel(
     }
 
     private fun validatePin(currentPin: String) {
+        setState { copy(isLoading = true) }
         viewModelScope.launch {
             interactor.isCurrentPinValid(
                 pin = currentPin
@@ -218,7 +219,8 @@ class PinViewModel(
                     is QuickPinInteractorPinValidPartialState.Failed -> {
                         setState {
                             copy(
-                                quickPinError = it.errorMessage
+                                quickPinError = it.errorMessage,
+                                isLoading = false
                             )
                         }
                     }
@@ -242,7 +244,8 @@ class PinViewModel(
                 buttonText = calculateButtonText(newPinState),
                 pin = "",
                 resetPin = true,
-                subtitle = calculateSubtitle(newPinState)
+                subtitle = calculateSubtitle(newPinState),
+                isLoading = false
             )
         }
     }
@@ -258,12 +261,14 @@ class PinViewModel(
                 buttonText = calculateButtonText(newPinState),
                 pin = "",
                 resetPin = true,
-                subtitle = calculateSubtitle(newPinState)
+                subtitle = calculateSubtitle(newPinState),
+                isLoading = false
             )
         }
     }
 
     private fun saveNewPin(newPin: String, enteredPin: String) {
+        setState { copy(isLoading = true) }
         viewModelScope.launch {
             interactor.setPin(
                 newPin = newPin,
@@ -273,7 +278,8 @@ class PinViewModel(
                     is QuickPinInteractorSetPinPartialState.Failed -> {
                         setState {
                             copy(
-                                quickPinError = it.errorMessage
+                                quickPinError = it.errorMessage,
+                                isLoading = false
                             )
                         }
                     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,8 +5,8 @@ androidGradlePlugin = "9.2.0"
 androidxActivity = "1.13.0"
 androidxAppCompat = "1.7.1"
 androidxBrowser = "1.10.0"
-androidxComposeBom = "2026.03.01"
-androidxComposeRuntimeTracing = "1.10.6"
+androidxComposeBom = "2026.04.01"
+androidxComposeRuntimeTracing = "1.11.0"
 androidxCore = "1.18.0"
 androidxCoreSplashscreen = "1.2.0"
 androidxDataStore = "1.2.1"
@@ -14,7 +14,7 @@ androidxEspresso = "3.7.0"
 androidxLifecycle = "2.10.0"
 androidxMacroBenchmark = "1.4.1"
 androidxMetrics = "1.0.0"
-androidxNavigation = "2.9.7"
+androidxNavigation = "2.9.8"
 androidxProfileinstaller = "1.4.1"
 androidxTestCore = "1.7.0"
 androidxTestExt = "1.3.0"
@@ -68,6 +68,7 @@ rqesUiSDK = "0.3.8"
 androidxRoom = "2.8.4"
 cloudy = "0.5.0"
 sqlcipher = "4.14.1"
+datastore = "1.3.0-alpha08"
 
 [libraries]
 accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
@@ -93,7 +94,6 @@ androidx-compose-ui-util = { group = "androidx.compose.ui", name = "ui-util" }
 androidx-constraintlayout-compose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "constraintlayoutVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "androidxCoreSplashscreen" }
-androidx-dataStore-core = { group = "androidx.datastore", name = "datastore", version.ref = "androidxDataStore" }
 androidx-lifecycle-runtimeCompose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewModelCompose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-metrics = { group = "androidx.metrics", name = "metrics-performance", version.ref = "androidxMetrics" }
@@ -102,6 +102,9 @@ androidx-appAuth = { group = "androidx.security", name = "security-app-authentic
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "androidxNavigation" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "androidxProfileinstaller" }
+androidx-datastore-prefs = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+androidx-datastore-core = { group = "androidx.datastore", name = "datastore-preferences-core", version.ref = "datastore" }
+androidx-datastore-tink = { group = "androidx.datastore", name = "datastore-tink", version.ref = "datastore" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxTestExt" }

--- a/storage-logic/src/main/java/eu/europa/ec/storagelogic/di/LogicStorageModule.kt
+++ b/storage-logic/src/main/java/eu/europa/ec/storagelogic/di/LogicStorageModule.kt
@@ -44,7 +44,7 @@ fun provideAppDatabase(
 ): DatabaseService {
     System.loadLibrary("sqlcipher")
     val key = prefKeys.getDbKey() ?: cryptoController.createRandomKey(context).also {
-        prefKeys.setDbKey(it.toString(Charsets.UTF_8))
+        prefKeys.setDbKey(it)
     }
     return Room.databaseBuilder(
         context,


### PR DESCRIPTION
This commit replaces the legacy `SharedPreferences` implementation with Jetpack `DataStore` and uses Google Tink for Authenticated Encryption with Associated Data (AEAD).

Key changes include:
- Migrated `PrefsControllerImpl` to use `DataStore` with `AeadSerializer` for secure key-value storage.
- Updated `PrefKeys` and `LogicStorageModule` to handle database encryption keys as `ByteArray` instead of `String`.
- Added `isLoading` state management in `PinViewModel` to provide UI feedback during PIN validation and storage operations.
- Updated `androidxComposeBom` to `2026.04.01`, `androidxNavigation` to `2.9.8`, and added `androidx-datastore` dependencies.
- Refactored visibility of constants in `PrefsPinStorageProvider` and `KeystoreController`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable