### PR TITLE
chore: enable async Arm Memory Tagging Extension (MTE)

### DIFF
--- a/assembly-logic/src/main/AndroidManifest.xml
+++ b/assembly-logic/src/main/AndroidManifest.xml
@@ -59,6 +59,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="${appName}${appNameSuffix}"
         android:largeHeap="true"
+        android:memtagMode="async"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"


### PR DESCRIPTION
Adds the `android:memtagMode="async"` attribute to the AndroidManifest.xml.

Ref: https://developer.android.com/ndk/guides/arm-mte

GrapheneOS forces memtag by default on Pixel 8+ devices, but for stock Pixels and other future Android devices, explicitly enabling this flag is a good practice to reinforce security.

## Type of change

Please delete options that are not relevant.

- [X ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- Built and ran the application locally to ensure there are no compilation errors or regressions on startup.
- Note: This is an OS/Hardware level security flag (Arm MTE). It does not affect standard functionality but provides hardware-assisted memory safety on supported devices (e.g., Pixel 8+).

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [] I have checked that my strings are *localized* where applicable