### PR TITLE
feat: enable StrongBox backing for keys in KeystoreController

### DIFF
--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/crypto/KeystoreController.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/crypto/KeystoreController.kt
@@ -97,6 +97,7 @@ class KeystoreControllerImpl(
             setKeySize(256)
             setBlockModes(KeyProperties.BLOCK_MODE_GCM)
             setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            setIsStrongBoxBacked(true)
             if (userAuthenticationRequired) {
                 setUserAuthenticationRequired(true)
                 setInvalidatedByBiometricEnrollment(true)


### PR DESCRIPTION
This commit updates the key generation configuration in `KeystoreController` to request StrongBox-backed security.

Key changes:
- Added `setIsStrongBoxBacked(true)` to the `KeyGenParameterSpec` builder to ensure keys are stored in a dedicated hardware security module when available.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable