### PR TITLE
test: expand unit test coverage for interactors and validators

### DIFF
--- a/business-logic/src/test/java/eu/europa/ec/businesslogic/validator/TestFilterValidator.kt
+++ b/business-logic/src/test/java/eu/europa/ec/businesslogic/validator/TestFilterValidator.kt
@@ -24,6 +24,7 @@ import eu.europa.ec.businesslogic.validator.model.FilterMultipleAction
 import eu.europa.ec.businesslogic.validator.model.FilterableList
 import eu.europa.ec.businesslogic.validator.model.Filters
 import eu.europa.ec.businesslogic.validator.model.SortOrder
+import eu.europa.ec.businesslogic.validator.util.TestAttributes
 import eu.europa.ec.businesslogic.validator.util.filterItemsMultiple
 import eu.europa.ec.businesslogic.validator.util.filterItemsSingle
 import eu.europa.ec.businesslogic.validator.util.filterableList
@@ -34,7 +35,6 @@ import eu.europa.ec.businesslogic.validator.util.filtersWithMultipleSelectionSiz
 import eu.europa.ec.businesslogic.validator.util.filtersWithMultipleSelectionSize4
 import eu.europa.ec.businesslogic.validator.util.filtersWithSingleSelection
 import eu.europa.ec.businesslogic.validator.util.multipleSelectionGroup
-import eu.europa.ec.businesslogic.validator.util.TestAttributes
 import eu.europa.ec.businesslogic.validator.util.singleSelectionGroup
 import eu.europa.ec.testlogic.extension.runFlowTest
 import eu.europa.ec.testlogic.extension.runTest
@@ -476,15 +476,16 @@ class TestFilterValidator {
 
     //region updateFilter group-type coverage
 
-    private val multiSelectionGroupForUpdate = FilterGroup.MultipleSelectionFilterGroup<TestAttributes>(
-        id = "ms_for_update",
-        name = "Multi",
-        filters = listOf(
-            FilterElement.FilterItem(id = "ms1", name = "PID", selected = false),
-            FilterElement.FilterItem(id = "ms2", name = "mDL", selected = true),
-        ),
-        filterableAction = FilterMultipleAction { attrs, filter -> attrs.name == filter.name },
-    )
+    private val multiSelectionGroupForUpdate =
+        FilterGroup.MultipleSelectionFilterGroup<TestAttributes>(
+            id = "ms_for_update",
+            name = "Multi",
+            filters = listOf(
+                FilterElement.FilterItem(id = "ms1", name = "PID", selected = false),
+                FilterElement.FilterItem(id = "ms2", name = "mDL", selected = true),
+            ),
+            filterableAction = FilterMultipleAction { attrs, filter -> attrs.name == filter.name },
+        )
 
     private val filtersMultiForUpdate = Filters(
         filterGroups = listOf(multiSelectionGroupForUpdate),
@@ -568,6 +569,266 @@ class TestFilterValidator {
                 // second initializeValidator call.
                 val emitted = awaitItem()
                 assertTrue(emitted is FilterValidatorPartialState.FilterListResult)
+            }
+        }
+    //endregion
+
+    //region updateDateFilter on all 4 group types
+    // updateDateFilter routes through the (date-version) updateFilterInGroup which has its own
+    // `when (group)` over all 4 FilterGroup subtypes. Only the SingleSelection variant was
+    // covered above; this adds the other three.
+
+    @Test
+    fun `Given a MultipleSelectionFilterGroup containing a DateTimeRangeFilterItem, When updateDateFilter is called, Then the range is updated`() =
+        coroutineRule.runTest {
+            filterValidator.onFilterStateChange().runFlowTest {
+                // Given
+                val group = FilterGroup.MultipleSelectionFilterGroup<TestAttributes>(
+                    id = "multi_date",
+                    name = "Multi Date",
+                    filters = listOf(
+                        FilterElement.DateTimeRangeFilterItem(
+                            id = "mdr1",
+                            name = "Range",
+                            selected = true,
+                            isDefault = true,
+                            startDateTime = LocalDateTime.MIN,
+                            endDateTime = LocalDateTime.MAX,
+                        ),
+                    ),
+                    filterableAction = FilterMultipleAction { _, _ -> true },
+                )
+                val filters = Filters(
+                    filterGroups = listOf(group),
+                    sortOrder = SortOrder.Descending(isDefault = true),
+                )
+                filterValidator.initializeValidator(filters, filterableList)
+
+                // When
+                filterValidator.updateDateFilter(
+                    filterGroupId = group.id,
+                    filterId = "mdr1",
+                    lowerLimit = LocalDateTime.of(2026, 1, 1, 0, 0),
+                    upperLimit = LocalDateTime.of(2026, 12, 31, 0, 0),
+                )
+
+                // Then
+                val state = awaitItem()
+                assertTrue(state is FilterValidatorPartialState.FilterUpdateResult)
+            }
+        }
+
+    @Test
+    fun `Given a ReversibleSingleSelectionFilterGroup containing a DateTimeRangeFilterItem, When updateDateFilter is called, Then the range is updated`() =
+        coroutineRule.runTest {
+            filterValidator.onFilterStateChange().runFlowTest {
+                // Given
+                val group = FilterGroup.ReversibleSingleSelectionFilterGroup(
+                    id = "rsingle_date",
+                    name = "Rev Single Date",
+                    filters = listOf(
+                        FilterElement.DateTimeRangeFilterItem(
+                            id = "rsdr1",
+                            name = "Range",
+                            selected = true,
+                            isDefault = true,
+                            startDateTime = LocalDateTime.MIN,
+                            endDateTime = LocalDateTime.MAX,
+                        ),
+                    ),
+                )
+                val filters = Filters(
+                    filterGroups = listOf(group),
+                    sortOrder = SortOrder.Descending(isDefault = true),
+                )
+                filterValidator.initializeValidator(filters, filterableList)
+
+                // When
+                filterValidator.updateDateFilter(
+                    filterGroupId = group.id,
+                    filterId = "rsdr1",
+                    lowerLimit = LocalDateTime.of(2026, 1, 1, 0, 0),
+                    upperLimit = LocalDateTime.of(2026, 12, 31, 0, 0),
+                )
+
+                // Then
+                val state = awaitItem()
+                assertTrue(state is FilterValidatorPartialState.FilterUpdateResult)
+            }
+        }
+
+    @Test
+    fun `Given a ReversibleMultipleSelectionFilterGroup containing a DateTimeRangeFilterItem, When updateDateFilter is called, Then the range is updated`() =
+        coroutineRule.runTest {
+            filterValidator.onFilterStateChange().runFlowTest {
+                // Given
+                val group = FilterGroup.ReversibleMultipleSelectionFilterGroup<TestAttributes>(
+                    id = "rmulti_date",
+                    name = "Rev Multi Date",
+                    filters = listOf(
+                        FilterElement.DateTimeRangeFilterItem(
+                            id = "rmdr1",
+                            name = "Range",
+                            selected = true,
+                            isDefault = true,
+                            startDateTime = LocalDateTime.MIN,
+                            endDateTime = LocalDateTime.MAX,
+                        ),
+                    ),
+                    filterableAction = FilterMultipleAction { _, _ -> true },
+                )
+                val filters = Filters(
+                    filterGroups = listOf(group),
+                    sortOrder = SortOrder.Descending(isDefault = true),
+                )
+                filterValidator.initializeValidator(filters, filterableList)
+
+                // When
+                filterValidator.updateDateFilter(
+                    filterGroupId = group.id,
+                    filterId = "rmdr1",
+                    lowerLimit = LocalDateTime.of(2026, 1, 1, 0, 0),
+                    upperLimit = LocalDateTime.of(2026, 12, 31, 0, 0),
+                )
+
+                // Then
+                val state = awaitItem()
+                assertTrue(state is FilterValidatorPartialState.FilterUpdateResult)
+            }
+        }
+    //endregion
+
+    //region applyReversibleSingleSelectionFilter & applyReversibleMultipleSelectionFilter
+    // These cover the Sort early-return and null-selectedFilter paths.
+
+    @Test
+    fun `Given a ReversibleSingleSelectionFilterGroup with a Sort action and applyFilters, Then the apply path returns the original list`() =
+        coroutineRule.runTest {
+            filterValidator.onFilterStateChange().runFlowTest {
+                // Given
+                val group = FilterGroup.ReversibleSingleSelectionFilterGroup(
+                    id = "rev_single_sort",
+                    name = "Rev Sort",
+                    filters = listOf(
+                        FilterElement.FilterItem(
+                            id = "rss",
+                            name = "Sort by name",
+                            selected = true,
+                            isDefault = true,
+                            filterableAction = FilterAction.Sort<TestAttributes, String> { it.name },
+                        ),
+                    ),
+                )
+                val filters = Filters(
+                    filterGroups = listOf(group),
+                    sortOrder = SortOrder.Ascending(isDefault = true),
+                )
+                filterValidator.initializeValidator(filters, filterableList)
+
+                // When
+                filterValidator.applyFilters()
+
+                // Then
+                val state = awaitItem()
+                assertTrue(state is FilterValidatorPartialState.FilterListResult)
+            }
+        }
+
+    @Test
+    fun `Given a ReversibleSingleSelectionFilterGroup with no selected filter and applyFilters, Then the original list is returned`() =
+        coroutineRule.runTest {
+            filterValidator.onFilterStateChange().runFlowTest {
+                // Given — no filter is selected → selectedFilter is null
+                val group = FilterGroup.ReversibleSingleSelectionFilterGroup(
+                    id = "rev_single_empty",
+                    name = "Rev Empty",
+                    filters = listOf(
+                        FilterElement.FilterItem(
+                            id = "rse",
+                            name = "X",
+                            selected = false,
+                            isDefault = false,
+                        ),
+                    ),
+                )
+                val filters = Filters(
+                    filterGroups = listOf(group),
+                    sortOrder = SortOrder.Ascending(isDefault = true),
+                )
+                filterValidator.initializeValidator(filters, filterableList)
+
+                // When
+                filterValidator.applyFilters()
+
+                // Then
+                val state = awaitItem()
+                assertTrue(state is FilterValidatorPartialState.FilterListResult)
+            }
+        }
+
+    @Test
+    fun `Given a ReversibleMultipleSelectionFilterGroup with no selected filter and applyFilters, Then the original list is returned`() =
+        coroutineRule.runTest {
+            filterValidator.onFilterStateChange().runFlowTest {
+                // Given — no filter selected → applyReversibleMultipleSelectionFilter returns currentList
+                val group = FilterGroup.ReversibleMultipleSelectionFilterGroup<TestAttributes>(
+                    id = "rev_multi_empty",
+                    name = "Rev Multi Empty",
+                    filters = listOf(
+                        FilterElement.FilterItem(
+                            id = "rme",
+                            name = "X",
+                            selected = false,
+                            isDefault = false,
+                        ),
+                    ),
+                    filterableAction = FilterMultipleAction { _, _ -> true },
+                )
+                val filters = Filters(
+                    filterGroups = listOf(group),
+                    sortOrder = SortOrder.Ascending(isDefault = true),
+                )
+                filterValidator.initializeValidator(filters, filterableList)
+
+                // When
+                filterValidator.applyFilters()
+
+                // Then
+                val state = awaitItem()
+                assertTrue(state is FilterValidatorPartialState.FilterListResult)
+            }
+        }
+
+    @Test
+    fun `Given a ReversibleMultipleSelectionFilterGroup with selected filters and applyFilters, Then the filterableAction is applied`() =
+        coroutineRule.runTest {
+            filterValidator.onFilterStateChange().runFlowTest {
+                // Given
+                val group = FilterGroup.ReversibleMultipleSelectionFilterGroup<TestAttributes>(
+                    id = "rev_multi_apply",
+                    name = "Rev Multi Apply",
+                    filters = listOf(
+                        FilterElement.FilterItem(
+                            id = "rma",
+                            name = "PID",
+                            selected = true,
+                            isDefault = false,
+                        ),
+                    ),
+                    filterableAction = FilterMultipleAction { attrs, filter -> attrs.name == filter.name },
+                )
+                val filters = Filters(
+                    filterGroups = listOf(group),
+                    sortOrder = SortOrder.Ascending(isDefault = true),
+                )
+                filterValidator.initializeValidator(filters, filterableList)
+
+                // When
+                filterValidator.applyFilters()
+
+                // Then
+                val state = awaitItem()
+                assertTrue(state is FilterValidatorPartialState.FilterListResult)
             }
         }
     //endregion

--- a/business-logic/src/test/java/eu/europa/ec/businesslogic/validator/TestFormValidator.kt
+++ b/business-logic/src/test/java/eu/europa/ec/businesslogic/validator/TestFormValidator.kt
@@ -1078,17 +1078,26 @@ class TestFormValidator {
     }
 
     @Test
-    fun testValidateDuplicateCharacterNotInConsecutiveOrder_belowThreshold() = coroutineRule.runTest {
-        // maxTimesOfConsecutiveOrder < 2 → always returns true (always valid).
-        val rules = listOf(
-            Rule.ValidateDuplicateCharacterNotInConsecutiveOrder(
-                maxTimesOfConsecutiveOrder = 1,
-                errorMessage = plainErrorMessage,
+    fun testValidateDuplicateCharacterNotInConsecutiveOrder_belowThreshold() =
+        coroutineRule.runTest {
+            // maxTimesOfConsecutiveOrder < 2 → always returns true (always valid).
+            val rules = listOf(
+                Rule.ValidateDuplicateCharacterNotInConsecutiveOrder(
+                    maxTimesOfConsecutiveOrder = 1,
+                    errorMessage = plainErrorMessage,
+                )
             )
-        )
-        validateForm(rules = rules, value = "aaaa", expectedValidationResult = validationSuccess)
-        validateForm(rules = rules, value = "abcd", expectedValidationResult = validationSuccess)
-    }
+            validateForm(
+                rules = rules,
+                value = "aaaa",
+                expectedValidationResult = validationSuccess
+            )
+            validateForm(
+                rules = rules,
+                value = "abcd",
+                expectedValidationResult = validationSuccess
+            )
+        }
 
     @Test
     fun testValidateNumericNotInConsecutiveSequenceOrder_shortCircuitGuards() =
@@ -1104,7 +1113,11 @@ class TestFormValidator {
             // Empty value → first OR-arm true
             validateForm(rules = rules, value = "", expectedValidationResult = validationSuccess)
             // Non-numeric → third OR-arm true (toIntOrNull() == null)
-            validateForm(rules = rules, value = "abcd", expectedValidationResult = validationSuccess)
+            validateForm(
+                rules = rules,
+                value = "abcd",
+                expectedValidationResult = validationSuccess
+            )
             // Length mismatch → fourth OR-arm true
             validateForm(rules = rules, value = "123", expectedValidationResult = validationSuccess)
 

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestDocumentDetailsInteractor.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestDocumentDetailsInteractor.kt
@@ -56,8 +56,8 @@ import eu.europa.ec.testfeature.util.mockedFormattedExpirationDate
 import eu.europa.ec.testfeature.util.mockedFormattedIssuanceDate
 import eu.europa.ec.testfeature.util.mockedGenericErrorMessage
 import eu.europa.ec.testfeature.util.mockedMdlId
-import eu.europa.ec.testfeature.util.mockedNotifyOnAuthenticationFailure
 import eu.europa.ec.testfeature.util.mockedMdocPidNameSpace
+import eu.europa.ec.testfeature.util.mockedNotifyOnAuthenticationFailure
 import eu.europa.ec.testfeature.util.mockedOldestPidId
 import eu.europa.ec.testfeature.util.mockedPidDocName
 import eu.europa.ec.testfeature.util.mockedPidId
@@ -499,6 +499,7 @@ class TestDocumentDetailsInteractor {
             }
         }
     }
+
     // Case 9:
     // Same as Case 1 but with wasIssuerDetailsExpanded = true → IssuerDetailsCardDataUi.isExpanded
     // is true (covers the non-null branch of `wasIssuerDetailsExpanded ?: false`).
@@ -859,6 +860,135 @@ class TestDocumentDetailsInteractor {
     }
     //endregion
 
+    // Case 11 (deleteDocument):
+    // The document is an SdJwt PID → the `docType` resolution falls through the
+    // `(format as? MsoMdocFormat)?.docType ?: (format as? SdJwtVcFormat)?.vct` chain to the
+    // SdJwt branch (line 598). With forcePidActivation=true and one SdJwt PID, the
+    // shouldDeleteAllDocuments branch returns true → deleteAllDocuments path.
+    @Test
+    fun `Given Case 11, When deleteDocument is called for an SdJwt PID, Then AllDocumentsDeleted is returned`() {
+        coroutineRule.runTest {
+            // Given
+            val sdJwtPid = eu.europa.ec.testfeature.util.getMockedSdJwtPidWithBasicFields()
+            mockGetAllDocumentsCall(response = listOf(sdJwtPid))
+            mockGetAllDocumentsWithTypeCall(response = listOf(sdJwtPid))
+            mockGetDocumentByIdCall(response = sdJwtPid)
+            mockDeleteAllDocumentsCall(response = DeleteAllDocumentsPartialState.Success)
+
+            // When
+            interactor.deleteDocument(documentId = sdJwtPid.id).runFlowTest {
+                // Then
+                assertEquals(
+                    DocumentDetailsInteractorDeleteDocumentPartialState.AllDocumentsDeleted,
+                    awaitItem()
+                )
+            }
+        }
+    }
+
+    // Case 12 (deleteDocument):
+    // Multiple PID documents exist; the document being deleted is NOT the main PID
+    // (allPidDocuments.count > 1 AND getMainPidDocument().id != documentId).
+    // → shouldDeleteAllDocuments evaluates false → single-document delete path.
+    @Test
+    fun `Given Case 12, When deleteDocument is called for a non-main PID with multiple PIDs, Then SingleDocumentDeleted is returned`() {
+        coroutineRule.runTest {
+            // Given
+            val mainPid = getMockedPidWithBasicFields()
+            val otherPid = getMockedOldestPidWithBasicFields()
+            mockGetAllDocumentsWithTypeCall(response = listOf(mainPid, otherPid))
+            mockGetDocumentByIdCall(response = otherPid)
+            mockGetMainPidDocument(response = mainPid)
+            mockDeleteDocumentCall(response = DeleteDocumentPartialState.Success)
+
+            // When
+            interactor.deleteDocument(documentId = otherPid.id).runFlowTest {
+                // Then
+                assertEquals(
+                    DocumentDetailsInteractorDeleteDocumentPartialState.SingleDocumentDeleted,
+                    awaitItem()
+                )
+            }
+        }
+    }
+    //endregion
+
+    // Case 13 (deleteDocument):
+    // forcePidActivation=true, doc is PID, allPidDocuments has exactly 1 entry → the
+    // `if (allPidDocuments.count() > 1)` false branch runs → `else true` returns true →
+    // shouldDeleteAllDocuments=true → deleteAllDocuments path with single PID present.
+    @Test
+    fun `Given Case 13, When deleteDocument is called for the single PID, Then AllDocumentsDeleted is returned`() {
+        coroutineRule.runTest {
+            // Given
+            val mainPid = getMockedPidWithBasicFields()
+            mockGetAllDocumentsWithTypeCall(response = listOf(mainPid))
+            mockGetDocumentByIdCall(response = mainPid)
+            mockDeleteAllDocumentsCall(response = DeleteAllDocumentsPartialState.Success)
+
+            // When
+            interactor.deleteDocument(documentId = mainPid.id).runFlowTest {
+                // Then
+                assertEquals(
+                    DocumentDetailsInteractorDeleteDocumentPartialState.AllDocumentsDeleted,
+                    awaitItem()
+                )
+            }
+        }
+    }
+
+    // Case 15 (deleteDocument):
+    // Multiple PIDs exist but getMainPidDocument returns null → the `?.id` safe-call returns
+    // null → `null == documentId` is false → shouldDeleteAllDocuments=false → SingleDocumentDeleted.
+    @Test
+    fun `Given Case 15, When deleteDocument is called and getMainPidDocument returns null, Then SingleDocumentDeleted is returned`() {
+        coroutineRule.runTest {
+            // Given
+            val pid1 = getMockedPidWithBasicFields()
+            val pid2 = getMockedOldestPidWithBasicFields()
+            mockGetAllDocumentsWithTypeCall(response = listOf(pid1, pid2))
+            mockGetDocumentByIdCall(response = pid1)
+            mockGetMainPidDocument(response = null)
+            mockDeleteDocumentCall(response = DeleteDocumentPartialState.Success)
+
+            // When
+            interactor.deleteDocument(documentId = pid1.id).runFlowTest {
+                // Then
+                assertEquals(
+                    DocumentDetailsInteractorDeleteDocumentPartialState.SingleDocumentDeleted,
+                    awaitItem()
+                )
+            }
+        }
+    }
+
+    // Case 14 (deleteDocument):
+    // forcePidActivation=true, doc is PID, multiple PIDs exist, AND getMainPidDocument().id
+    // matches the documentId being deleted → the inner `getMainPidDocument()?.id == documentId`
+    // branch evaluates true → shouldDeleteAllDocuments=true → deleteAllDocuments path.
+    @Test
+    fun `Given Case 14, When deleteDocument is called for the main PID with multiple PIDs, Then AllDocumentsDeleted is returned`() {
+        coroutineRule.runTest {
+            // Given
+            val mainPid = getMockedPidWithBasicFields()
+            val otherPid = getMockedOldestPidWithBasicFields()
+            mockGetAllDocumentsWithTypeCall(response = listOf(mainPid, otherPid))
+            mockGetDocumentByIdCall(response = mainPid)
+            mockGetMainPidDocument(response = mainPid)
+            mockDeleteAllDocumentsCall(response = DeleteAllDocumentsPartialState.Success)
+
+            // When
+            interactor.deleteDocument(documentId = mainPid.id).runFlowTest {
+                // Then
+                assertEquals(
+                    DocumentDetailsInteractorDeleteDocumentPartialState.AllDocumentsDeleted,
+                    awaitItem()
+                )
+            }
+        }
+    }
+    //endregion
+
     //region storeBookmark()
     // Case 1:
     // 1. A valid bookmarkId is provided.
@@ -998,7 +1128,8 @@ class TestDocumentDetailsInteractor {
                     allowAuthorizationFallback = true,
                 )
             ).thenReturn(
-                IssueDocumentsPartialState.Failure(errorMessage = mockedPlainFailureMessage).toFlow()
+                IssueDocumentsPartialState.Failure(errorMessage = mockedPlainFailureMessage)
+                    .toFlow()
             )
 
             // When

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestDocumentsInteractor.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestDocumentsInteractor.kt
@@ -43,6 +43,7 @@ import eu.europa.ec.eudi.wallet.document.Document
 import eu.europa.ec.eudi.wallet.document.DocumentId
 import eu.europa.ec.resourceslogic.provider.ResourceProvider
 import eu.europa.ec.testfeature.util.getMockedFullDocuments
+import eu.europa.ec.testfeature.util.getMockedFullPid
 import eu.europa.ec.testfeature.util.mockedExceptionWithMessage
 import eu.europa.ec.testfeature.util.mockedExceptionWithNoMessage
 import eu.europa.ec.testfeature.util.mockedGenericErrorMessage
@@ -54,6 +55,7 @@ import eu.europa.ec.testlogic.rule.CoroutineTestRule
 import eu.europa.ec.uilogic.component.ListItemDataUi
 import eu.europa.ec.uilogic.component.ListItemMainContentDataUi
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
 import kotlinx.coroutines.flow.emptyFlow
 import org.junit.After
 import org.junit.Before
@@ -892,6 +894,159 @@ class TestDocumentsInteractor {
     }
     //endregion
 
+    //region getDocuments — UnsignedDocument & expired
+
+    @Test
+    fun `Given an UnsignedDocument among getAllDocuments, When getDocuments is called, Then it is mapped with Pending state`() {
+        coroutineRule.runTest {
+            // Given
+            val mockedFullDocuments = getMockedFullDocuments()
+            val unsignedDoc =
+                org.mockito.kotlin.mock<eu.europa.ec.eudi.wallet.document.UnsignedDocument>()
+            whenever(unsignedDoc.id).thenReturn("unsigned-id")
+            whenever(unsignedDoc.name).thenReturn("Unsigned Doc")
+            whenever(unsignedDoc.format).thenReturn(eu.europa.ec.testfeature.util.mockedMdocPidFormat)
+            whenever(unsignedDoc.issuerMetadata).thenReturn(null)
+
+            whenever(walletCoreDocumentsController.getMainPidDocument())
+                .thenReturn(mockedFullDocuments[0])
+            // Cast to List<Document> since both IssuedDocument and UnsignedDocument implement Document.
+            @Suppress("UNCHECKED_CAST")
+            whenever(walletCoreDocumentsController.getAllDocuments())
+                .thenReturn(mockedFullDocuments + listOf(unsignedDoc) as List<Document>)
+            whenever(walletCoreDocumentsController.getAllDocumentCategories())
+                .thenReturn(DocumentCategories(value = emptyMap()))
+            whenever(walletCoreDocumentsController.isDocumentRevoked(anyString())).thenReturn(false)
+            whenever(walletCoreDocumentsController.isDocumentLowOnCredentials(org.mockito.kotlin.any()))
+                .thenReturn(false)
+            whenever(resourceProvider.getLocale())
+                .thenReturn(eu.europa.ec.testfeature.util.mockedDefaultLocale)
+            whenever(resourceProvider.getString(org.mockito.kotlin.any())).thenReturn("mocked")
+            whenever(
+                resourceProvider.getString(
+                    org.mockito.kotlin.any(),
+                    org.mockito.kotlin.any<Int>(),
+                    org.mockito.kotlin.any<Int>()
+                )
+            ).thenReturn("mocked-credentials-info")
+            whenever(
+                resourceProvider.getString(
+                    org.mockito.kotlin.any(),
+                    org.mockito.kotlin.any<String>()
+                )
+            ).thenReturn("mocked-expiry-message")
+
+            // When
+            interactor.getDocuments().runFlowTest {
+                // Then
+                val state = awaitItem()
+                assertTrue(state is DocumentInteractorGetDocumentsPartialState.Success)
+                state as DocumentInteractorGetDocumentsPartialState.Success
+                val unsignedItem = state.allDocuments.items.firstOrNull {
+                    (it.payload as? DocumentUi)?.uiData?.itemId == "unsigned-id"
+                }
+                assertNotNull(unsignedItem)
+                val payload = unsignedItem!!.payload as DocumentUi
+                assertEquals(DocumentIssuanceStateUi.Pending, payload.documentIssuanceState)
+            }
+        }
+    }
+
+    @Test
+    fun `Given an expired IssuedDocument, When getDocuments is called, Then documentIssuanceState is Failed`() {
+        coroutineRule.runTest {
+            // Given
+            val mockedFullPid = getMockedFullPid()
+            val pidFormat = mockedFullPid.format
+            val pidData = mockedFullPid.data
+            // Override validUntil to a past date so documentHasExpired evaluates true.
+            val expiredPid =
+                org.mockito.kotlin.mock<eu.europa.ec.eudi.wallet.document.IssuedDocument>()
+            whenever(expiredPid.id).thenReturn("expired-pid-id")
+            whenever(expiredPid.name).thenReturn("Expired PID")
+            whenever(expiredPid.format).thenReturn(pidFormat)
+            whenever(expiredPid.data).thenReturn(pidData)
+            whenever(expiredPid.issuerMetadata).thenReturn(null)
+            whenever(expiredPid.getValidUntil()).thenReturn(
+                Result.success(java.time.Instant.parse("2020-01-01T00:00:00Z"))
+            )
+            whenever(expiredPid.credentialsCount()).thenReturn(3)
+            whenever(expiredPid.initialCredentialsCount()).thenReturn(5)
+
+            whenever(walletCoreDocumentsController.getMainPidDocument()).thenReturn(expiredPid)
+            whenever(walletCoreDocumentsController.getAllDocuments())
+                .thenReturn(listOf(expiredPid))
+            whenever(walletCoreDocumentsController.getAllDocumentCategories())
+                .thenReturn(DocumentCategories(value = emptyMap()))
+            whenever(walletCoreDocumentsController.isDocumentRevoked(anyString())).thenReturn(false)
+            whenever(walletCoreDocumentsController.isDocumentLowOnCredentials(org.mockito.kotlin.any()))
+                .thenReturn(false)
+            whenever(resourceProvider.getLocale())
+                .thenReturn(eu.europa.ec.testfeature.util.mockedDefaultLocale)
+            whenever(resourceProvider.getString(org.mockito.kotlin.any())).thenReturn("mocked")
+            whenever(
+                resourceProvider.getString(
+                    org.mockito.kotlin.any(),
+                    org.mockito.kotlin.any<Int>(),
+                    org.mockito.kotlin.any<Int>()
+                )
+            ).thenReturn("mocked-credentials-info")
+            whenever(
+                resourceProvider.getString(
+                    org.mockito.kotlin.any(),
+                    org.mockito.kotlin.any<String>()
+                )
+            ).thenReturn("mocked-expiry-message")
+
+            // When
+            interactor.getDocuments().runFlowTest {
+                // Then
+                val state = awaitItem()
+                assertTrue(state is DocumentInteractorGetDocumentsPartialState.Success)
+                state as DocumentInteractorGetDocumentsPartialState.Success
+                val payload = state.allDocuments.items.first().payload as DocumentUi
+                assertEquals(DocumentIssuanceStateUi.Failed, payload.documentIssuanceState)
+            }
+        }
+    }
+    //endregion
+
+    //region onFilterStateChange — non-DocumentUi payload
+
+    @Test
+    fun `Given a FilterApplyResult that contains a non-DocumentUi payload, When onFilterStateChange emits it, Then that item is filtered out`() {
+        coroutineRule.runTest {
+            // Given
+            val foreignItem = FilterableItem(
+                payload = ForeignDocPayload,
+                attributes = object : FilterableAttributes {
+                    override val searchTags: List<String> = emptyList()
+                },
+            )
+            mockOnFilterChangedEvent(
+                FilterValidatorPartialState.FilterListResult.FilterApplyResult(
+                    filteredList = FilterableList(items = listOf(foreignItem)),
+                    allDefaultFiltersAreSelected = true,
+                    updatedFilters = Filters.emptyFilters(),
+                )
+            )
+
+            // When
+            interactor.onFilterStateChange().runFlowTest {
+                // Then
+                val state = awaitItem()
+                assertTrue(state is DocumentInteractorFilterPartialState.FilterApplyResult)
+                state as DocumentInteractorFilterPartialState.FilterApplyResult
+                val total = state.documents.sumOf { it.second.size }
+                assertEquals(0, total)
+            }
+        }
+    }
+
+    private object ForeignDocPayload :
+        eu.europa.ec.businesslogic.validator.model.FilterableItemPayload
+    //endregion
+
     //region getFilters lambdas
 
     @Test
@@ -1065,6 +1220,120 @@ class TestDocumentsInteractor {
     }
     //endregion
 
+    //region addDynamicFilters default parameter
+    // The interface declares `filters: Filters = Filters.emptyFilters()`. Calling without
+    // the filters argument exercises the default-parameter synthetic.
+    @Test
+    fun `When addDynamicFilters is called without filters, Then the default emptyFilters is used`() {
+        // Given
+        whenever(resourceProvider.getString(org.mockito.kotlin.any())).thenReturn("mocked")
+        val documents = FilterableList(items = emptyList())
+
+        // When
+        val result = interactor.addDynamicFilters(documents = documents)
+
+        // Then
+        // Default filters is Filters.emptyFilters() which has empty filterGroups.
+        assertEquals(0, result.filterGroups.size)
+    }
+    //endregion
+
+    //region addDynamicFilters & period predicates
+
+    @Test
+    fun `Given a documents list with issuers and categories, When addDynamicFilters is called, Then the ISSUER and CATEGORY groups are populated`() {
+        // Given
+        whenever(resourceProvider.getString(org.mockito.kotlin.any())).thenReturn("mocked")
+        val itemAcme = FilterableItem(
+            payload = stubDocumentUi(),
+            attributes = documentsAttributes(
+                issuer = "Acme",
+                category = eu.europa.ec.corelogic.model.DocumentCategory.Government,
+            ),
+        )
+        val itemSchool = FilterableItem(
+            payload = stubDocumentUi(),
+            attributes = documentsAttributes(
+                issuer = "School",
+                category = eu.europa.ec.corelogic.model.DocumentCategory.Education,
+            ),
+        )
+        val documents = FilterableList(items = listOf(itemAcme, itemSchool))
+        val initialFilters = interactor.getFilters()
+
+        // When
+        val result = interactor.addDynamicFilters(documents, initialFilters)
+
+        // Then
+        val issuerGroup = result.filterGroups.first {
+            it.id == eu.europa.ec.dashboardfeature.ui.documents.list.model.DocumentFilterIds.FILTER_BY_ISSUER_GROUP_ID
+        }
+        val categoryGroup = result.filterGroups.first {
+            it.id == eu.europa.ec.dashboardfeature.ui.documents.list.model.DocumentFilterIds.FILTER_BY_DOCUMENT_CATEGORY_GROUP_ID
+        }
+        assertEquals(2, issuerGroup.filters.size)
+        assertEquals(2, categoryGroup.filters.size)
+    }
+
+    @Test
+    fun `When the period filter predicates are applied, Then default issuance and expiry-window predicates evaluate as expected`() {
+        // Given
+        whenever(resourceProvider.getString(org.mockito.kotlin.any())).thenReturn("mocked")
+        val periodGroup = interactor.getFilters().filterGroups.first {
+            it.id == eu.europa.ec.dashboardfeature.ui.documents.list.model.DocumentFilterIds.FILTER_BY_PERIOD_GROUP_ID
+        }
+
+        val defaultPred =
+            periodGroup.filters[0].filterableAction as eu.europa.ec.businesslogic.validator.model.FilterAction.Filter<DocumentsFilterableAttributes>
+        val next7Pred =
+            periodGroup.filters[1].filterableAction as eu.europa.ec.businesslogic.validator.model.FilterAction.Filter<DocumentsFilterableAttributes>
+        val next30Pred =
+            periodGroup.filters[2].filterableAction as eu.europa.ec.businesslogic.validator.model.FilterAction.Filter<DocumentsFilterableAttributes>
+        val beyond30Pred =
+            periodGroup.filters[3].filterableAction as eu.europa.ec.businesslogic.validator.model.FilterAction.Filter<DocumentsFilterableAttributes>
+        val expiredPred =
+            periodGroup.filters[4].filterableAction as eu.europa.ec.businesslogic.validator.model.FilterAction.Filter<DocumentsFilterableAttributes>
+
+        val dummyFilter = eu.europa.ec.businesslogic.validator.model.FilterElement.FilterItem(
+            id = "x", name = "x", selected = true, isDefault = false,
+        )
+
+        val expired = documentsAttributes(
+            expiryDate = java.time.Instant.parse("2020-01-01T00:00:00Z"),
+        )
+        val tomorrow = documentsAttributes(
+            expiryDate = java.time.Instant.now().plus(1, java.time.temporal.ChronoUnit.DAYS),
+        )
+        val nextMonth = documentsAttributes(
+            expiryDate = java.time.Instant.now().plus(20, java.time.temporal.ChronoUnit.DAYS),
+        )
+        val farFuture = documentsAttributes(
+            expiryDate = java.time.Instant.now().plus(365, java.time.temporal.ChronoUnit.DAYS),
+        )
+
+        // When + Then
+        assertTrue(defaultPred.predicate(expired, dummyFilter))
+        assertTrue(next7Pred.predicate(tomorrow, dummyFilter))
+        assertTrue(!next7Pred.predicate(farFuture, dummyFilter))
+        assertTrue(next30Pred.predicate(nextMonth, dummyFilter))
+        assertTrue(!next30Pred.predicate(farFuture, dummyFilter))
+        assertTrue(beyond30Pred.predicate(farFuture, dummyFilter))
+        assertTrue(!beyond30Pred.predicate(tomorrow, dummyFilter))
+        assertTrue(expiredPred.predicate(expired, dummyFilter))
+        assertTrue(!expiredPred.predicate(farFuture, dummyFilter))
+    }
+
+    private fun stubDocumentUi(): DocumentUi = DocumentUi(
+        documentIssuanceState = DocumentIssuanceStateUi.Issued,
+        uiData = ListItemDataUi(
+            itemId = "any",
+            mainContentData = ListItemMainContentDataUi.Text("any"),
+        ),
+        documentIdentifier = DocumentIdentifier.MdocPid,
+        documentCategory = eu.europa.ec.corelogic.model.DocumentCategory.Government,
+    )
+    //endregion
+
     //region filterValidator delegation
     // These tests verify the simple delegation methods to filterValidator.
 
@@ -1117,7 +1386,8 @@ class TestDocumentsInteractor {
         interactor.updateSortOrder(sortOrder = order)
 
         // Then
-        org.mockito.kotlin.verify(filterValidator, org.mockito.kotlin.times(1)).updateSortOrder(order)
+        org.mockito.kotlin.verify(filterValidator, org.mockito.kotlin.times(1))
+            .updateSortOrder(order)
     }
 
     @Test

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestHomeInteractor.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestHomeInteractor.kt
@@ -27,11 +27,11 @@ import eu.europa.ec.testfeature.util.mockedExceptionWithMessage
 import eu.europa.ec.testfeature.util.mockedExceptionWithNoMessage
 import eu.europa.ec.testfeature.util.mockedGenericErrorMessage
 import eu.europa.ec.testfeature.util.mockedUserFirstName
-import eu.europa.ec.testlogic.extension.runFlowTest
-import eu.europa.ec.testlogic.extension.runTest
 import eu.europa.ec.testfeature.walletcore.getMockedEudiWalletConfig
 import eu.europa.ec.testlogic.base.TestApplication
 import eu.europa.ec.testlogic.base.getMockedContext
+import eu.europa.ec.testlogic.extension.runFlowTest
+import eu.europa.ec.testlogic.extension.runTest
 import eu.europa.ec.testlogic.rule.CoroutineTestRule
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestTransactionDetailsInteractor.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestTransactionDetailsInteractor.kt
@@ -530,6 +530,36 @@ class TestTransactionDetailsInteractor {
     }
     //endregion
 
+    //region sealed Failure arms (data-class API surface)
+    // The interactor only emits Success today, but the Failure arms are part of the sealed
+    // API surface so the data-class equals/hashCode/copy/toString need exercise.
+    @Test
+    fun `Given requestDataDeletion Failure data class, When instantiated, Then equals_hashCode_copy work`() {
+        val a =
+            TransactionDetailsInteractorRequestDataDeletionPartialState.Failure(errorMessage = "err")
+        val b = a.copy(errorMessage = "err")
+        val c =
+            TransactionDetailsInteractorRequestDataDeletionPartialState.Failure(errorMessage = "other")
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertEquals("err", a.errorMessage)
+        kotlin.test.assertNotEquals(a, c)
+    }
+
+    @Test
+    fun `Given reportSuspiciousTransaction Failure data class, When instantiated, Then equals_hashCode_copy work`() {
+        val a =
+            TransactionDetailsInteractorReportSuspiciousTransactionPartialState.Failure(errorMessage = "err")
+        val b = a.copy(errorMessage = "err")
+        val c =
+            TransactionDetailsInteractorReportSuspiciousTransactionPartialState.Failure(errorMessage = "other")
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertEquals("err", a.errorMessage)
+        kotlin.test.assertNotEquals(a, c)
+    }
+    //endregion
+
     //region helper functions
     private fun mockTransactionDetailsStrings() {
         whenever(resourceProvider.getString(R.string.transactions_screen_filters_filter_by_transaction_type_issuance))

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestTransactionsInteractor.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/interactor/TestTransactionsInteractor.kt
@@ -31,22 +31,22 @@ import eu.europa.ec.businesslogic.validator.model.Filters
 import eu.europa.ec.businesslogic.validator.model.SortOrder
 import eu.europa.ec.corelogic.controller.WalletCoreDocumentsController
 import eu.europa.ec.corelogic.model.TransactionLogDataDomain
-import eu.europa.ec.eudi.wallet.document.metadata.IssuerMetadata
-import eu.europa.ec.eudi.wallet.transactionLogging.presentation.PresentedDocument
-import eu.europa.ec.testfeature.util.mockedMdocPidFormat
 import eu.europa.ec.dashboardfeature.ui.transactions.list.model.TransactionCategoryUi
 import eu.europa.ec.dashboardfeature.ui.transactions.list.model.TransactionFilterIds
 import eu.europa.ec.dashboardfeature.ui.transactions.list.model.TransactionUi
 import eu.europa.ec.dashboardfeature.ui.transactions.list.model.TransactionsFilterableAttributes
 import eu.europa.ec.dashboardfeature.ui.transactions.model.TransactionStatusUi
 import eu.europa.ec.dashboardfeature.ui.transactions.model.TransactionTypeUi
+import eu.europa.ec.eudi.wallet.document.metadata.IssuerMetadata
 import eu.europa.ec.eudi.wallet.transactionLogging.TransactionLog
+import eu.europa.ec.eudi.wallet.transactionLogging.presentation.PresentedDocument
 import eu.europa.ec.resourceslogic.R
 import eu.europa.ec.resourceslogic.provider.ResourceProvider
 import eu.europa.ec.testfeature.util.mockedDefaultLocale
 import eu.europa.ec.testfeature.util.mockedExceptionWithMessage
 import eu.europa.ec.testfeature.util.mockedExceptionWithNoMessage
 import eu.europa.ec.testfeature.util.mockedGenericErrorMessage
+import eu.europa.ec.testfeature.util.mockedMdocPidFormat
 import eu.europa.ec.testlogic.extension.runFlowTest
 import eu.europa.ec.testlogic.extension.runTest
 import eu.europa.ec.testlogic.extension.toFlow
@@ -318,7 +318,8 @@ class TestTransactionsInteractor {
             // is stable for any clock-state except the first 2 hours after midnight; the test
             // dispatcher used here is wall-clock-driven so this picks the Today branch reliably
             // during business-hour CI runs and remains a documented limitation otherwise.
-            val nowMinusTwoHours = LocalDateTime.now().minusHours(2).withMinute(0).withSecond(0).withNano(0)
+            val nowMinusTwoHours =
+                LocalDateTime.now().minusHours(2).withMinute(0).withSecond(0).withNano(0)
             val today = if (nowMinusTwoHours.toLocalDate() == LocalDateTime.now().toLocalDate()) {
                 nowMinusTwoHours
             } else {
@@ -691,6 +692,7 @@ class TestTransactionsInteractor {
         val sortGroup = filters.filterGroups.first {
             it.id == TransactionFilterIds.FILTER_SORT_GROUP_ID
         }
+
         @Suppress("UNCHECKED_CAST")
         val sortAction = sortGroup.filters.first().filterableAction
                 as FilterAction.Sort<TransactionsFilterableAttributes, LocalDateTime>
@@ -711,6 +713,7 @@ class TestTransactionsInteractor {
         val dateGroup = filters.filterGroups.first {
             it.id == TransactionFilterIds.FILTER_BY_TRANSACTION_DATE_GROUP_ID
         }
+
         @Suppress("UNCHECKED_CAST")
         val dateAction = dateGroup.filters.first().filterableAction
                 as FilterAction.Filter<TransactionsFilterableAttributes>
@@ -751,6 +754,7 @@ class TestTransactionsInteractor {
         val statusGroup = filters.filterGroups.first {
             it.id == TransactionFilterIds.FILTER_BY_STATUS_GROUP_ID
         }
+
         @Suppress("UNCHECKED_CAST")
         val statusAction =
             (statusGroup as FilterGroup.MultipleSelectionFilterGroup<TransactionsFilterableAttributes>)
@@ -775,11 +779,36 @@ class TestTransactionsInteractor {
         )
 
         // When + Then
-        assertTrue(statusAction.predicate(attributes(status = TransactionStatusUi.Completed), completedFilter))
-        assertTrue(!statusAction.predicate(attributes(status = TransactionStatusUi.Failed), completedFilter))
-        assertTrue(statusAction.predicate(attributes(status = TransactionStatusUi.Failed), failedFilter))
-        assertTrue(!statusAction.predicate(attributes(status = TransactionStatusUi.Completed), failedFilter))
-        assertTrue(statusAction.predicate(attributes(status = TransactionStatusUi.Completed), otherFilter))
+        assertTrue(
+            statusAction.predicate(
+                attributes(status = TransactionStatusUi.Completed),
+                completedFilter
+            )
+        )
+        assertTrue(
+            !statusAction.predicate(
+                attributes(status = TransactionStatusUi.Failed),
+                completedFilter
+            )
+        )
+        assertTrue(
+            statusAction.predicate(
+                attributes(status = TransactionStatusUi.Failed),
+                failedFilter
+            )
+        )
+        assertTrue(
+            !statusAction.predicate(
+                attributes(status = TransactionStatusUi.Completed),
+                failedFilter
+            )
+        )
+        assertTrue(
+            statusAction.predicate(
+                attributes(status = TransactionStatusUi.Completed),
+                otherFilter
+            )
+        )
     }
 
     @Test
@@ -790,6 +819,7 @@ class TestTransactionsInteractor {
         val rpGroup = filters.filterGroups.first {
             it.id == TransactionFilterIds.FILTER_BY_RELYING_PARTY_GROUP_ID
         }
+
         @Suppress("UNCHECKED_CAST")
         val rpAction =
             (rpGroup as FilterGroup.MultipleSelectionFilterGroup<TransactionsFilterableAttributes>)
@@ -828,6 +858,7 @@ class TestTransactionsInteractor {
         val typeGroup = filters.filterGroups.first {
             it.id == TransactionFilterIds.FILTER_BY_TRANSACTION_TYPE_GROUP_ID
         }
+
         @Suppress("UNCHECKED_CAST")
         val typeAction =
             (typeGroup as FilterGroup.MultipleSelectionFilterGroup<TransactionsFilterableAttributes>)
@@ -859,12 +890,42 @@ class TestTransactionsInteractor {
 
         // When + Then — also exercise the `==` false outcomes by mismatching the filter's
         // expected type against the attribute's type so each arm sees the equality return false.
-        assertTrue(typeAction.predicate(attributes(type = TransactionTypeUi.PRESENTATION), presentationFilter))
-        assertTrue(!typeAction.predicate(attributes(type = TransactionTypeUi.ISSUANCE), presentationFilter))
-        assertTrue(typeAction.predicate(attributes(type = TransactionTypeUi.ISSUANCE), issuanceFilter))
-        assertTrue(!typeAction.predicate(attributes(type = TransactionTypeUi.PRESENTATION), issuanceFilter))
-        assertTrue(typeAction.predicate(attributes(type = TransactionTypeUi.SIGNING), signingFilter))
-        assertTrue(!typeAction.predicate(attributes(type = TransactionTypeUi.PRESENTATION), signingFilter))
+        assertTrue(
+            typeAction.predicate(
+                attributes(type = TransactionTypeUi.PRESENTATION),
+                presentationFilter
+            )
+        )
+        assertTrue(
+            !typeAction.predicate(
+                attributes(type = TransactionTypeUi.ISSUANCE),
+                presentationFilter
+            )
+        )
+        assertTrue(
+            typeAction.predicate(
+                attributes(type = TransactionTypeUi.ISSUANCE),
+                issuanceFilter
+            )
+        )
+        assertTrue(
+            !typeAction.predicate(
+                attributes(type = TransactionTypeUi.PRESENTATION),
+                issuanceFilter
+            )
+        )
+        assertTrue(
+            typeAction.predicate(
+                attributes(type = TransactionTypeUi.SIGNING),
+                signingFilter
+            )
+        )
+        assertTrue(
+            !typeAction.predicate(
+                attributes(type = TransactionTypeUi.PRESENTATION),
+                signingFilter
+            )
+        )
         assertTrue(!typeAction.predicate(attributes(type = TransactionTypeUi.SIGNING), otherFilter))
     }
     //endregion
@@ -1029,6 +1090,21 @@ class TestTransactionsInteractor {
         selected = true,
         isDefault = true,
     )
+    //endregion
+
+    //region DateTimeCategoryPartialState sealed arms (data-class API surface)
+    // The Today/WithinLastHour/etc. arms are produced from clock-driven branches inside
+    // getTransactions; exercise the data-class methods directly for stable coverage.
+    @Test
+    fun `Given Today partial-state data class, When instantiated, Then equals_hashCode_copy work`() {
+        val a = TransactionInteractorDateTimeCategoryPartialState.Today(time = "10:30")
+        val b = a.copy(time = "10:30")
+        val c = TransactionInteractorDateTimeCategoryPartialState.Today(time = "11:30")
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertEquals("10:30", a.time)
+        kotlin.test.assertNotEquals(a, c)
+    }
     //endregion
 
     //region mocked objects

--- a/issuance-feature/src/test/java/eu/europa/ec/issuancefeature/interactor/TestAddDocumentInteractor.kt
+++ b/issuance-feature/src/test/java/eu/europa/ec/issuancefeature/interactor/TestAddDocumentInteractor.kt
@@ -531,7 +531,8 @@ class TestAddDocumentInteractor {
                     issuerId = "issuerId",
                 )
             ).thenReturn(
-                IssueDocumentsPartialState.Failure(errorMessage = mockedPlainFailureMessage).toFlow()
+                IssueDocumentsPartialState.Failure(errorMessage = mockedPlainFailureMessage)
+                    .toFlow()
             )
 
             // When
@@ -860,6 +861,7 @@ class TestAddDocumentInteractor {
         val expectedResult = "SUCCESS?successConfig=$mockedRouteArguments"
         assertEquals(expectedResult, result)
     }
+
     // Case 3:
     // 1. uiSerializer.toBase64 returns null → the `.orEmpty()` fallback path is exercised,
     //    producing a route with an empty successConfig argument.

--- a/issuance-feature/src/test/java/eu/europa/ec/issuancefeature/interactor/TestDocumentOfferInteractor.kt
+++ b/issuance-feature/src/test/java/eu/europa/ec/issuancefeature/interactor/TestDocumentOfferInteractor.kt
@@ -510,6 +510,112 @@ class TestDocumentOfferInteractor {
         }
     //endregion
 
+    // Case 11:
+    // Offer with txCodeSpec = null. The `safeLet` over `response.offer.txCodeSpec?.inputMode`
+    // and `?.length` returns null → both inner branches are skipped via the safe-call
+    // null path. Combined with hasMainPid = true, the rest of the flow continues to Success.
+    @Test
+    fun `Given Case 11, When resolveDocumentOffer is called with a null txCodeSpec, Then Success is returned`() =
+        coroutineRule.runTest {
+            // Given
+            val mockedOffer = mockOffer(
+                issuerName = mockedIssuerName,
+                offeredDocuments = mockedOfferedDocumentsList,
+                txCodeSpec = null,
+            )
+            mockGetMainPidDocumentCall(mainPid = getMockedMainPid())
+            mockWalletDocumentsControllerResolveOfferEventEmission(
+                event = ResolveDocumentOfferPartialState.Success(mockedOffer)
+            )
+
+            // When
+            interactor.resolveDocumentOffer(mockedUriPath1).runFlowTest {
+                // Then
+                val state = awaitItem()
+                org.junit.Assert.assertTrue(
+                    state is ResolveDocumentOfferInteractorPartialState.Success
+                )
+            }
+        }
+
+    // Case 12:
+    // Offer with txCodeSpec.inputMode = TEXT → the `inputMode == TxCodeInputMode.TEXT` arm of
+    // the `||` returns true → Failure with invalid-txcode-format message.
+    @Test
+    fun `Given Case 12, When resolveDocumentOffer is called with TEXT inputMode, Then Failure with invalid-format message is returned`() =
+        coroutineRule.runTest {
+            // Given
+            val mockedOffer = mockOffer(
+                issuerName = mockedIssuerName,
+                offeredDocuments = mockedOfferedDocumentsList,
+                txCodeSpec = mockOfferTxCodeSpec(
+                    inputMode = TxCodeInputMode.TEXT,
+                    length = 4,
+                ),
+            )
+            mockGetMainPidDocumentCall(mainPid = getMockedMainPid())
+            whenever(
+                resourceProvider.getString(
+                    R.string.issuance_document_offer_error_invalid_txcode_format,
+                    4,
+                    6,
+                )
+            ).thenReturn(mockedInvalidCodeFormatMessage)
+            mockWalletDocumentsControllerResolveOfferEventEmission(
+                event = ResolveDocumentOfferPartialState.Success(mockedOffer)
+            )
+
+            // When
+            interactor.resolveDocumentOffer(mockedUriPath1).runFlowTest {
+                // Then
+                assertEquals(
+                    ResolveDocumentOfferInteractorPartialState.Failure(
+                        errorMessage = mockedInvalidCodeFormatMessage
+                    ),
+                    awaitItem()
+                )
+            }
+        }
+
+    // Case 13:
+    // Offer with txCodeSpec.length out of [4..6] → the `length !in codeMinLength..codeMaxLength`
+    // arm returns true → Failure.
+    @Test
+    fun `Given Case 13, When resolveDocumentOffer is called with txCode length out of range, Then Failure is returned`() =
+        coroutineRule.runTest {
+            // Given
+            val mockedOffer = mockOffer(
+                issuerName = mockedIssuerName,
+                offeredDocuments = mockedOfferedDocumentsList,
+                txCodeSpec = mockOfferTxCodeSpec(
+                    inputMode = TxCodeInputMode.NUMERIC,
+                    length = 8,
+                ),
+            )
+            mockGetMainPidDocumentCall(mainPid = getMockedMainPid())
+            whenever(
+                resourceProvider.getString(
+                    R.string.issuance_document_offer_error_invalid_txcode_format,
+                    4,
+                    6,
+                )
+            ).thenReturn(mockedInvalidCodeFormatMessage)
+            mockWalletDocumentsControllerResolveOfferEventEmission(
+                event = ResolveDocumentOfferPartialState.Success(mockedOffer)
+            )
+
+            // When
+            interactor.resolveDocumentOffer(mockedUriPath1).runFlowTest {
+                // Then
+                assertEquals(
+                    ResolveDocumentOfferInteractorPartialState.Failure(
+                        errorMessage = mockedInvalidCodeFormatMessage
+                    ),
+                    awaitItem()
+                )
+            }
+        }
+
     //region issueDocuments
 
     // Case 1:

--- a/presentation-feature/src/test/java/eu/europa/ec/presentationfeature/interactor/TestPresentationSuccessInteractor.kt
+++ b/presentation-feature/src/test/java/eu/europa/ec/presentationfeature/interactor/TestPresentationSuccessInteractor.kt
@@ -37,15 +37,11 @@ import eu.europa.ec.testlogic.extension.runFlowTest
 import eu.europa.ec.testlogic.extension.runTest
 import eu.europa.ec.testlogic.rule.CoroutineTestRule
 import eu.europa.ec.uilogic.component.AppIcons
-import eu.europa.ec.uilogic.component.ListItemDataUi
 import eu.europa.ec.uilogic.component.ListItemMainContentDataUi
 import eu.europa.ec.uilogic.component.ListItemTrailingContentDataUi
 import eu.europa.ec.uilogic.component.RelyingPartyDataUi
 import eu.europa.ec.uilogic.component.content.ContentHeaderConfig
-import eu.europa.ec.uilogic.component.wrap.ExpandableListItemUi
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNotNull
-import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
 import org.junit.After
 import org.junit.Before

--- a/proximity-feature/src/test/java/eu/europa/ec/proximityfeature/interactor/TestProximityRequestInteractor.kt
+++ b/proximity-feature/src/test/java/eu/europa/ec/proximityfeature/interactor/TestProximityRequestInteractor.kt
@@ -640,6 +640,7 @@ class TestProximityRequestInteractor {
                 }
         }
     }
+
     // Case 13:
     // RequestReceived with non-empty requestData, but every issued document is filtered out
     // because isDocumentRevoked returns true for all. Exercises the


### PR DESCRIPTION
This commit significantly increases unit test coverage across multiple feature modules, focusing on edge cases, state transitions, and data-class API surfaces.

Key changes include:
- **DocumentDetailsInteractor**: Added comprehensive tests for `deleteDocument` logic, covering SdJwt PID handling, main vs. non-main PID deletion, and scenarios with multiple documents.
- **DocumentsInteractor**: Added tests for `getDocuments` to verify handling of `UnsignedDocument` and expired documents. Expanded coverage for dynamic filter population and period-based predicates.
- **DocumentOfferInteractor**: Added test cases for `resolveDocumentOffer` to validate `txCodeSpec` requirements, including null specs, invalid input modes (TEXT), and out-of-range lengths.
- **FilterValidator**: Improved coverage for `updateDateFilter` across all `FilterGroup` subtypes and added tests for reversible selection filter groups.
- **Data Class Coverage**: Added tests to exercise `equals`, `hashCode`, and `copy` methods for sealed state arms in `TransactionsInteractor` and `TransactionDetailsInteractor`.
- **General Cleanup**: Refactored formatting and removed unused imports across several test files to improve maintainability.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [x] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
