### PR TITLE
build: enable resource shrinking for release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         release {
             isDebuggable = false
             isMinifyEnabled = true
+            isShrinkResources = true
             applicationIdSuffix = AppBuildType.RELEASE.applicationIdSuffix
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(

--- a/wiki/GO_LIVE.md
+++ b/wiki/GO_LIVE.md
@@ -1736,6 +1736,7 @@ Current release builds set:
 
 ```kotlin
 isMinifyEnabled = true
+isShrinkResources = true
 proguardFiles(
     getDefaultProguardFile("proguard-android-optimize.txt"),
     "proguard-rules.pro"


### PR DESCRIPTION
This commit enables resource shrinking for the release build type to further reduce the application's size by removing unused resources.

Key changes include:
- Set `isShrinkResources = true` in the release build configuration within `app/build.gradle.kts`.
- Updated the `wiki/GO_LIVE.md` documentation to reflect the inclusion of resource shrinking in the recommended release setup.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
