### PR TITLE
fix: remove syntax error in biometric string resource

### DIFF
--- a/resources-logic/src/main/res/values/strings.xml
+++ b/resources-logic/src/main/res/values/strings.xml
@@ -131,7 +131,7 @@
     <!-- region Biometrics -->
     <string name="biometric_no_hardware">Your device does not support biometric authentication</string>
     <string name="biometric_unknown_error">Something went wrong initializing biometric authentication. Please try again</string>
-    <string name="biometric_default_mode_text_above_pin_field">PIN</string>">
+    <string name="biometric_default_mode_text_above_pin_field">PIN</string>
     <!--endregion-->
 
     <!-- region Document Success -->


### PR DESCRIPTION
This commit removes an extra `">` suffix accidentally included after the closing tag of the `biometric_default_mode_text_above_pin_field` string resource in `strings.xml`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
