### PR TITLE
style: update dark theme color value and refine .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,3 @@ fastlane/report.xml
 
 # Kotlin
 .kotlin/*
-
-# extensions
-*.apk

--- a/resources-logic/src/main/java/eu/europa/ec/resourceslogic/theme/values/ThemeColors.kt
+++ b/resources-logic/src/main/java/eu/europa/ec/resourceslogic/theme/values/ThemeColors.kt
@@ -105,7 +105,7 @@ class ThemeColors {
         private const val eudiw_theme_dark_onSecondaryContainer: Long = 0xFF3A3E57
         private const val eudiw_theme_dark_tertiary: Long = 0xFF1F2B25
         private const val eudiw_theme_dark_onTertiary: Long = 0xFF29322E
-        private const val eudiw_theme_dark_tertiaryContainer: Long = 0xFF1F2B25
+        private const val eudiw_theme_dark_tertiaryContainer: Long = 0xFF1F372B
         private const val eudiw_theme_dark_onTertiaryContainer: Long = 0xFF38413D
         private const val eudiw_theme_dark_error: Long = 0xFFFFB4AA
         private const val eudiw_theme_dark_onError: Long = 0xFF690003


### PR DESCRIPTION
This commit updates the dark theme tertiary container color for better visual consistency and cleans up the project's `.gitignore` file.

Key changes include:
- Updated the hex value for `eudiw_theme_dark_tertiaryContainer` in `ThemeColors.kt`.
- Removed the `*.apk` exclusion and associated comments from `.gitignore`.
- Refactored the Kotlin-related entries in `.gitignore` for better formatting.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
