### PR TITLE
chore: update Kotlin and various library dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EUDI Android Wallet reference application
 
 [![License: EUPL 1.2](https://img.shields.io/badge/License-EUPL%201.2-blue.svg)](https://joinup.ec.europa.eu/software/page/eupl)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-7F52FF.svg?logo=kotlin)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-7F52FF.svg?logo=kotlin)](https://kotlinlang.org)
 [![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-2026.05.01-4285F4.svg?logo=jetpackcompose)](https://developer.android.com/jetpack/compose)
 [![Android API](https://img.shields.io/badge/Android%20API-29%2B-3DDC84.svg?logo=android)](https://developer.android.com/about/versions/10)
 [![SonarCloud](https://img.shields.io/badge/SonarCloud-enabled-F3702A.svg?logo=sonarcloud)](https://sonarcloud.io)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Kotlin
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 kotlinxCoroutines = "1.11.0"
 kotlinxDatetime = "0.8.0"
 kotlinxSerializationJson = "1.11.0"
@@ -12,7 +12,7 @@ androidxAppAuth = "1.0.0"
 androidxAppCompat = "1.7.1"
 androidxBiometric = "1.4.0-alpha07"
 androidxBrowser = "1.10.0"
-androidxCore = "1.18.0"
+androidxCore = "1.19.0"
 androidxCoreSplashscreen = "1.2.0"
 androidxCredentials = "1.0.0-alpha04"
 androidxLifecycle = "2.10.0"
@@ -38,7 +38,7 @@ materialIcons = "1.7.8"
 cameraCore = "1.6.1"
 
 # Coil (image loading)
-coil = "3.4.0"
+coil = "3.5.0"
 
 # Ktor (networking)
 ktor = "3.5.0"
@@ -46,7 +46,7 @@ ktor = "3.5.0"
 # Koin (dependency injection)
 koin = "4.2.1"
 koinAnnotations = "4.2.1"
-koinPlugin = "1.0.0"
+koinPlugin = "1.0.1"
 
 # EUDI wallet SDKs
 eudiWalletCore = "0.28.1"
@@ -59,11 +59,11 @@ treessence = "1.1.2"
 
 # Other libraries
 androidDesugarJdkLibs = "2.1.5"
-googlePhoneNumber = "9.0.31"
+googlePhoneNumber = "9.0.32"
 gson = "2.14.0"
 lint = "32.2.1"
 material = "1.14.0"
-protobuf = "4.35.0"
+protobuf = "4.35.1"
 sqlcipher = "4.16.0"
 zxing = "3.5.4"
 
@@ -86,12 +86,12 @@ turbine = "1.2.1"
 androidGradlePlugin = "9.2.1"
 baselineprofile = "1.5.0-alpha06"
 dependencyGraphPlugin = "0.13.0"
-gmsPlugin = "4.4.4"
+gmsPlugin = "4.5.0"
 kover = "0.9.8"
 owaspDependencyCheck = "12.2.2"
 protobufPlugin = "0.10.0"
 secrets = "2.0.1"
-sonar = "7.3.0.8198"
+sonar = "7.3.1.8318"
 
 [libraries]
 # Kotlin


### PR DESCRIPTION
This commit updates the project's dependency versions in the Version Catalog and reflects the Kotlin upgrade in the documentation.

Key changes include:
- Updated Kotlin from 2.3.21 to 2.4.0.
- Bumped `androidxCore` to 1.19.0 and `coil` to 3.5.0.
- Updated build plugins: `gmsPlugin` (4.5.0), `koinPlugin` (1.0.1), and `sonar` (7.3.1.8318).
- Incremented minor versions for `googlePhoneNumber` (9.0.32) and `protobuf` (4.35.1).
- Updated the Kotlin version badge in `README.md` to match the new version.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
