### PR TITLE
Replace Treessence dependency with custom FileLoggerTree

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -21,9 +21,6 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://plugins.gradle.org/m2/")
         }
-        maven {
-            url = uri("https://jitpack.io")
-        }
         mavenLocal()
     }
     versionCatalogs {

--- a/business-logic/build.gradle.kts
+++ b/business-logic/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     implementation(libs.androidx.appAuth)
     implementation(libs.google.phonenumber)
     implementation(libs.timber)
-    implementation(libs.treessence)
     implementation(libs.androidx.datastore.prefs)
     implementation(libs.androidx.datastore.core)
     implementation(libs.androidx.datastore.tink)

--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/log/LogController.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/controller/log/LogController.kt
@@ -21,7 +21,7 @@ import android.net.Uri
 import android.util.Log
 import androidx.core.content.FileProvider
 import eu.europa.ec.businesslogic.config.ConfigLogic
-import fr.bipi.treessence.file.FileLoggerTree
+import eu.europa.ec.businesslogic.util.FileLoggerTree
 import timber.log.Timber
 import java.io.File
 

--- a/business-logic/src/main/java/eu/europa/ec/businesslogic/util/FileLoggerTree.kt
+++ b/business-logic/src/main/java/eu/europa/ec/businesslogic/util/FileLoggerTree.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.businesslogic.util
+
+import android.util.Log
+import timber.log.Timber
+import java.io.File
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.logging.FileHandler
+import java.util.logging.Formatter
+import java.util.logging.Level
+import java.util.logging.LogRecord
+
+/**
+ * A [Timber.Tree] that appends log messages to a rotating set of files.
+ *
+ * Replaces `fr.bipi.treessence.file.FileLoggerTree`, which was only distributed through
+ * JitPack. Rotation is delegated to [FileHandler], so the file name follows
+ * `java.util.logging` conventions: `%g` is substituted with the generation number of each
+ * rotated file.
+ */
+class FileLoggerTree private constructor(
+    private val minPriority: Int,
+    private val fileLimit: Int,
+    private val pathPattern: String,
+    private val handler: FileHandler,
+) : Timber.Tree() {
+
+    /**
+     * The log files that currently exist on disk.
+     *
+     * Names are derived from the configured pattern rather than by listing the directory,
+     * so the `.lck` lock files [FileHandler] keeps alongside them are never exposed.
+     */
+    val files: List<File>
+        get() = (0 until fileLimit)
+            .map { File(pathPattern.replace(GENERATION_PLACEHOLDER, it.toString())) }
+            .distinct()
+            .filter { it.exists() }
+
+    /** Releases the underlying file handles. */
+    fun close() = handler.close()
+
+    override fun isLoggable(tag: String?, priority: Int): Boolean = priority >= minPriority
+
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        handler.publish(LogRecord(priority.toLevel(), format(priority, tag, message, t)))
+    }
+
+    private fun format(priority: Int, tag: String?, message: String, t: Throwable?): String =
+        buildString {
+            append(priority.toPriorityChar())
+            append('/')
+            append(tag ?: DEFAULT_TAG)
+            append(": ")
+            append(message)
+            if (t != null) {
+                append(System.lineSeparator())
+                append(t.stackTraceToString())
+            }
+        }
+
+    private fun Int.toLevel(): Level = when (this) {
+        Log.VERBOSE -> Level.FINER
+        Log.DEBUG -> Level.FINE
+        Log.INFO -> Level.INFO
+        Log.WARN -> Level.WARNING
+        Log.ERROR, Log.ASSERT -> Level.SEVERE
+        else -> Level.INFO
+    }
+
+    private fun Int.toPriorityChar(): Char = when (this) {
+        Log.VERBOSE -> 'V'
+        Log.DEBUG -> 'D'
+        Log.INFO -> 'I'
+        Log.WARN -> 'W'
+        Log.ERROR -> 'E'
+        Log.ASSERT -> 'A'
+        else -> '?'
+    }
+
+    class Builder {
+        private var fileName: String = DEFAULT_FILE_NAME
+        private var dir: File? = null
+        private var sizeLimit: Int = DEFAULT_SIZE_LIMIT
+        private var fileLimit: Int = DEFAULT_FILE_LIMIT
+        private var minPriority: Int = Log.DEBUG
+        private var append: Boolean = true
+
+        fun withFileName(fileName: String) = apply { this.fileName = fileName }
+
+        fun withDir(dir: File) = apply { this.dir = dir }
+
+        fun withSizeLimit(sizeLimit: Int) = apply { this.sizeLimit = sizeLimit }
+
+        fun withFileLimit(fileLimit: Int) = apply { this.fileLimit = fileLimit }
+
+        fun withMinPriority(priority: Int) = apply { this.minPriority = priority }
+
+        fun appendToFile(append: Boolean) = apply { this.append = append }
+
+        @Throws(IOException::class)
+        fun build(): FileLoggerTree {
+            val logDir = requireNotNull(dir) { "A log directory must be set via withDir()." }
+            if (!logDir.exists() && !logDir.mkdirs()) {
+                throw IOException("Unable to create log directory ${logDir.absolutePath}")
+            }
+            val pathPattern = File(logDir, fileName).absolutePath
+            val handler = FileHandler(pathPattern, sizeLimit, fileLimit, append).apply {
+                formatter = TimestampFormatter()
+                level = Level.ALL
+            }
+            return FileLoggerTree(minPriority, fileLimit, pathPattern, handler)
+        }
+    }
+
+    private companion object {
+        const val GENERATION_PLACEHOLDER = "%g"
+        const val DEFAULT_FILE_NAME = "log%g.txt"
+        const val DEFAULT_SIZE_LIMIT = 1048576
+        const val DEFAULT_FILE_LIMIT = 3
+        const val DEFAULT_TAG = "EUDI"
+    }
+}
+
+/** Prefixes each already-formatted record with a timestamp and terminates the line. */
+private class TimestampFormatter : Formatter() {
+
+    private val dateFormat = SimpleDateFormat(TIMESTAMP_PATTERN, Locale.US)
+
+    override fun format(record: LogRecord): String =
+        "${dateFormat.format(Date(record.millis))} ${record.message}${System.lineSeparator()}"
+
+    private companion object {
+        const val TIMESTAMP_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS"
+    }
+}

--- a/business-logic/src/test/java/eu/europa/ec/businesslogic/util/TestFileLoggerTree.kt
+++ b/business-logic/src/test/java/eu/europa/ec/businesslogic/util/TestFileLoggerTree.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work
+ * except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the Licence for the specific language
+ * governing permissions and limitations under the Licence.
+ */
+
+package eu.europa.ec.businesslogic.util
+
+import android.util.Log
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import timber.log.Timber
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class TestFileLoggerTree {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private var tree: FileLoggerTree? = null
+
+    @Before
+    fun before() {
+        Timber.uprootAll()
+    }
+
+    @After
+    fun after() {
+        Timber.uprootAll()
+        tree?.close()
+    }
+
+    private val logsDir: File
+        get() = File(temporaryFolder.root, "logs")
+
+    /** Builds the tree and plants it, so logging goes through the real Timber path. */
+    private fun plantTree(
+        sizeLimit: Int = 1048576,
+        fileLimit: Int = 3,
+        minPriority: Int = Log.DEBUG,
+    ): FileLoggerTree = FileLoggerTree.Builder()
+        .withFileName(FILE_NAME)
+        .withDir(logsDir)
+        .withSizeLimit(sizeLimit)
+        .withFileLimit(fileLimit)
+        .withMinPriority(minPriority)
+        .appendToFile(true)
+        .build()
+        .also {
+            tree = it
+            Timber.plant(it)
+        }
+
+    @Test
+    fun `Given a message at minPriority, When logged, Then it is written to the log file`() {
+        val logger = plantTree()
+
+        Timber.tag("TAG").d("hello world")
+
+        Assert.assertTrue(logger.files.single().readText().contains("D/TAG: hello world"))
+    }
+
+    @Test
+    fun `Given a message below minPriority, When logged, Then it is not written`() {
+        val logger = plantTree(minPriority = Log.WARN)
+
+        Timber.tag("TAG").d("should be dropped")
+        Timber.tag("TAG").e("should be kept")
+
+        val contents = logger.files.single().readText()
+        Assert.assertTrue(contents.contains("E/TAG: should be kept"))
+        Assert.assertTrue(!contents.contains("should be dropped"))
+    }
+
+    @Test
+    fun `Given a throwable, When logged, Then its stack trace is appended`() {
+        val logger = plantTree()
+
+        Timber.tag("TAG").e(IllegalStateException("kaboom"), "boom")
+
+        val contents = logger.files.single().readText()
+        Assert.assertTrue(contents.contains("E/TAG: boom"))
+        Assert.assertTrue(contents.contains("IllegalStateException"))
+        Assert.assertTrue(contents.contains("kaboom"))
+    }
+
+    @Test
+    fun `Given no explicit tag, When logged, Then the default tag is used`() {
+        val logger = plantTree()
+
+        Timber.i("untagged")
+
+        Assert.assertTrue(logger.files.single().readText().contains("I/EUDI: untagged"))
+    }
+
+    @Test
+    fun `Given writes past the size limit, When logging, Then output rotates across files`() {
+        val logger = plantTree(sizeLimit = 256, fileLimit = 3)
+
+        repeat(40) { Timber.tag("TAG").d("message number %s", it) }
+
+        Assert.assertTrue(
+            "expected rotation, got ${logger.files.size} file(s)",
+            logger.files.size > 1
+        )
+        Assert.assertTrue(logger.files.size <= 3)
+    }
+
+    @Test
+    fun `Given lock files beside the logs, When files is read, Then only log files are returned`() {
+        val logger = plantTree()
+        Timber.tag("TAG").d("hello")
+
+        Assert.assertTrue(logsDir.listFiles().orEmpty().any { it.name.endsWith(".lck") })
+        Assert.assertTrue(logger.files.none { it.name.endsWith(".lck") })
+    }
+
+    @Test
+    fun `Given a directory that does not exist yet, When building, Then it is created`() {
+        val logger = plantTree()
+
+        Timber.tag("TAG").d("hello")
+
+        Assert.assertEquals(1, logger.files.size)
+        Assert.assertTrue(logsDir.isDirectory)
+    }
+
+    private companion object {
+        const val FILE_NAME = "eudi-android-wallet-logs%g.txt"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,6 @@ eudiLibKmpEtsi1196x2 = "0.4.0-alpha.1"
 # Logging
 slf4j = "2.0.19"
 timber = "5.0.1"
-treessence = "1.1.2"
 
 # Other libraries
 androidDesugarJdkLibs = "2.1.5"
@@ -180,7 +179,6 @@ eudi-lib-kmp-etsi119602-consultation = { module = "eu.europa.ec.eudi:etsi-119602
 # Logging
 slf4j = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
-treessence = { group = "com.github.bastienpaulfr", name = "Treessence", version.ref = "treessence" }
 
 # Other libraries
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,9 +36,6 @@ dependencyResolutionManagement {
             url = uri("https://central.sonatype.com/repository/maven-snapshots/")
             mavenContent { snapshotsOnly() }
         }
-        maven {
-            url = uri("https://jitpack.io")
-        }
         mavenLocal()
     }
 }


### PR DESCRIPTION
- Implemented an internal `FileLoggerTree` based on `java.util.logging.FileHandler` to replace `fr.bipi.treessence.file.FileLoggerTree`.
- Removed the `treessence` dependency from the version catalog and `business-logic` module.
- Removed the JitPack repository from `settings.gradle.kts` and `build-logic/settings.gradle.kts`.
- Added unit tests covering `FileLoggerTree` logging, rotation, and file filtering.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [x] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
