### PR TITLE
test: add unit tests for BiometricViewModel and SettingsViewModel

### DIFF
--- a/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/controller/authentication/BiometricAuthenticationController.kt
+++ b/authentication-logic/src/main/java/eu/europa/ec/authenticationlogic/controller/authentication/BiometricAuthenticationController.kt
@@ -156,47 +156,6 @@ class BiometricAuthenticationControllerImpl(
         }
     }
 
-    private suspend fun authenticateWithCrypto(
-        activity: FragmentActivity,
-        notifyOnAuthenticationFailure: Boolean,
-    ): BiometricsAuthenticate {
-        val storedCrypto = retrieveCrypto()
-        val biometricData = storedCrypto.first
-        val cipher = storedCrypto.second ?: return BiometricsAuthenticate.Failed(
-            activity.getString(
-                R.string.biometric_authentication_error
-            )
-        )
-
-        val data = authenticate(
-            activity = activity,
-            biometryCrypto = BiometricCrypto(BiometricPrompt.CryptoObject(cipher)),
-            promptInfo = BiometricPrompt.PromptInfo.Builder()
-                .setTitle(activity.getString(R.string.biometric_prompt_title))
-                .setSubtitle(activity.getString(R.string.biometric_prompt_subtitle))
-                .setAllowedAuthenticators(BIOMETRIC_STRONG)
-                .setNegativeButtonText(activity.getString(R.string.generic_cancel))
-                .build(),
-            notifyOnAuthenticationFailure = notifyOnAuthenticationFailure
-        )
-
-        return if (data.authenticationResult != null) {
-            verifyCrypto(
-                context = activity,
-                result = data.authenticationResult,
-                biometricAuthentication = biometricData
-            )
-        } else if (BiometricsAuthError.entries.any { it.code == data.errorCode }) {
-            BiometricsAuthenticate.Cancelled
-        } else {
-            BiometricsAuthenticate.Failed(
-                data.errorString.toString().ifBlank {
-                    activity.getString(R.string.biometric_authentication_error)
-                }
-            )
-        }
-    }
-
     override fun launchBiometricSystemScreen(authenticators: Int) {
         val enrollIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             Intent(Settings.ACTION_BIOMETRIC_ENROLL).apply {
@@ -262,6 +221,47 @@ class BiometricAuthenticationControllerImpl(
                 it
             )
         } ?: prompt.authenticate(promptInfo)
+    }
+
+    private suspend fun authenticateWithCrypto(
+        activity: FragmentActivity,
+        notifyOnAuthenticationFailure: Boolean,
+    ): BiometricsAuthenticate {
+        val storedCrypto = retrieveCrypto()
+        val biometricData = storedCrypto.first
+        val cipher = storedCrypto.second ?: return BiometricsAuthenticate.Failed(
+            activity.getString(
+                R.string.biometric_authentication_error
+            )
+        )
+
+        val data = authenticate(
+            activity = activity,
+            biometryCrypto = BiometricCrypto(BiometricPrompt.CryptoObject(cipher)),
+            promptInfo = BiometricPrompt.PromptInfo.Builder()
+                .setTitle(activity.getString(R.string.biometric_prompt_title))
+                .setSubtitle(activity.getString(R.string.biometric_prompt_subtitle))
+                .setAllowedAuthenticators(BIOMETRIC_STRONG)
+                .setNegativeButtonText(activity.getString(R.string.generic_cancel))
+                .build(),
+            notifyOnAuthenticationFailure = notifyOnAuthenticationFailure
+        )
+
+        return if (data.authenticationResult != null) {
+            verifyCrypto(
+                context = activity,
+                result = data.authenticationResult,
+                biometricAuthentication = biometricData
+            )
+        } else if (BiometricsAuthError.entries.any { it.code == data.errorCode }) {
+            BiometricsAuthenticate.Cancelled
+        } else {
+            BiometricsAuthenticate.Failed(
+                data.errorString.toString().ifBlank {
+                    activity.getString(R.string.biometric_authentication_error)
+                }
+            )
+        }
     }
 
     private suspend fun retrieveCrypto(): Pair<BiometricAuthentication?, Cipher?> =

--- a/common-feature/src/test/java/eu/europa/ec/commonfeature/ui/biometric/TestBiometricViewModel.kt
+++ b/common-feature/src/test/java/eu/europa/ec/commonfeature/ui/biometric/TestBiometricViewModel.kt
@@ -20,25 +20,36 @@ import android.content.Context
 import androidx.lifecycle.ViewModelStore
 import eu.europa.ec.authenticationlogic.controller.authentication.BiometricsAuthenticate
 import eu.europa.ec.authenticationlogic.controller.authentication.BiometricsAvailability
+import eu.europa.ec.authenticationlogic.provider.PinLockoutState
 import eu.europa.ec.authenticationlogic.secure.SecurePinImpl
+import eu.europa.ec.businesslogic.extension.toUri
 import eu.europa.ec.commonfeature.config.BiometricMode
 import eu.europa.ec.commonfeature.config.BiometricUiConfig
 import eu.europa.ec.commonfeature.config.OnBackNavigationConfig
 import eu.europa.ec.commonfeature.interactor.BiometricInteractor
 import eu.europa.ec.commonfeature.interactor.QuickPinInteractorPinValidPartialState
+import eu.europa.ec.resourceslogic.R
 import eu.europa.ec.resourceslogic.provider.ResourceProvider
 import eu.europa.ec.testlogic.extension.runFlowTest
 import eu.europa.ec.testlogic.extension.runTest
 import eu.europa.ec.testlogic.rule.CoroutineTestRule
 import eu.europa.ec.uilogic.config.ConfigNavigation
+import eu.europa.ec.uilogic.config.FlowCompletion
 import eu.europa.ec.uilogic.config.NavigationType
+import eu.europa.ec.uilogic.navigation.CommonScreens
+import eu.europa.ec.uilogic.navigation.DashboardScreens
 import eu.europa.ec.uilogic.serializer.UiSerializer
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -48,10 +59,14 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @RunWith(RobolectricTestRunner::class)
 class TestBiometricViewModel {
@@ -98,6 +113,14 @@ class TestBiometricViewModel {
         ).thenReturn(config)
         whenever(interactor.getBiometricsAvailability())
             .thenReturn(BiometricsAvailability.CanAuthenticate)
+        whenever(interactor.maxFailedPinAttempts).thenReturn(MAX_ATTEMPTS)
+        whenever(resources.getString(eq(R.string.quick_pin_locked_out), any(), any()))
+            .thenAnswer { invocation ->
+                val args = invocation.arguments.drop(1).flatMap {
+                    if (it is Array<*>) it.toList() else listOf(it)
+                }
+                args.joinToString(separator = ":", prefix = "locked:")
+            }
 
         doAnswer {
             callbacks += it.getArgument<(BiometricsAuthenticate) -> Unit>(2)
@@ -211,7 +234,539 @@ class TestBiometricViewModel {
         pin.close()
     }
 
+    @Test
+    fun `a manual attempt without enrollment opens the system setup screen`() =
+        coroutineRule.runTest {
+            whenever(interactor.getBiometricsAvailability())
+                .thenReturn(BiometricsAvailability.NonEnrolled)
+
+            viewModel.effect.runFlowTest {
+                viewModel.handleEvents(click)
+
+                assertEquals(Effect.Navigation.LaunchBiometricsSystemScreen, awaitItem())
+                assertEquals(0, callbacks.size)
+            }
+        }
+
+    @Test
+    fun `an automatic attempt without enrollment stays silent`() = coroutineRule.runTest {
+        whenever(interactor.getBiometricsAvailability())
+            .thenReturn(BiometricsAvailability.NonEnrolled)
+
+        viewModel.effect.runFlowTest {
+            viewModel.handleEvents(click.copy(shouldThrowErrorIfNotAvailable = false))
+            coroutineRule.testScope.runCurrent()
+
+            assertNull(viewModel.viewState.value.error)
+            assertEquals(0, callbacks.size)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `an unsupported biometrics explanation can be dismissed from its own action`() =
+        coroutineRule.runTest {
+            whenever(interactor.getBiometricsAvailability())
+                .thenReturn(BiometricsAvailability.Failure("Unsupported biometrics"))
+
+            viewModel.handleEvents(click)
+            assertNotNull(viewModel.viewState.value.error)
+
+            viewModel.viewState.value.error?.onCancel?.invoke()
+            coroutineRule.testScope.runCurrent()
+
+            assertNull(viewModel.viewState.value.error)
+        }
+
+    @Test
+    fun `a new lockout replaces the tick already running`() = coroutineRule.runTest {
+        lockViewModelOut(30.seconds)
+        assertEquals("locked:$MAX_ATTEMPTS:00:30", viewModel.viewState.value.lockoutMessage)
+
+        whenever(interactor.getPinLockoutState()).thenReturn(lockout(90.seconds))
+        viewModel.handleEvents(Event.Init)
+        coroutineRule.testScope.runCurrent()
+
+        assertEquals("locked:$MAX_ATTEMPTS:01:30", viewModel.viewState.value.lockoutMessage)
+
+        coroutineRule.testScope.advanceTimeBy(1_500.milliseconds)
+        coroutineRule.testScope.runCurrent()
+
+        assertEquals("locked:$MAX_ATTEMPTS:01:29", viewModel.viewState.value.lockoutMessage)
+
+        coroutineRule.testScope.advanceTimeBy(30_000.milliseconds)
+
+        assertTrue(viewModel.viewState.value.isLockedOut)
+        assertEquals("locked:$MAX_ATTEMPTS:00:59", viewModel.viewState.value.lockoutMessage)
+    }
+
+    @Test
+    fun `init publishes the biometric preference and asks for the prompt`() =
+        coroutineRule.runTest {
+            whenever(interactor.getBiometricUserSelection()).thenReturn(true)
+            whenever(interactor.getPinLockoutState()).thenReturn(PinLockoutState.Idle)
+
+            viewModel.effect.runFlowTest {
+                viewModel.handleEvents(Event.Init)
+                coroutineRule.testScope.runCurrent()
+
+                assertTrue(viewModel.viewState.value.userBiometricsAreEnabled)
+                assertEquals(Effect.InitializeBiometricAuthOnCreate, awaitItem())
+            }
+        }
+
+    @Test
+    fun `init keeps the prompt closed when biometrics are disabled`() = coroutineRule.runTest {
+        whenever(interactor.getBiometricUserSelection()).thenReturn(false)
+        whenever(interactor.getPinLockoutState()).thenReturn(PinLockoutState.Idle)
+
+        viewModel.effect.runFlowTest {
+            viewModel.handleEvents(Event.Init)
+            coroutineRule.testScope.runCurrent()
+
+            assertFalse(viewModel.viewState.value.userBiometricsAreEnabled)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `init keeps the prompt closed when the screen opts out`() = coroutineRule.runTest {
+        whenever(interactor.getBiometricUserSelection()).thenReturn(true)
+        whenever(interactor.getPinLockoutState()).thenReturn(PinLockoutState.Idle)
+        val optedOut = newViewModel(
+            "optedOut",
+            config(shouldInitializeBiometricAuthOnCreate = false)
+        )
+
+        optedOut.effect.runFlowTest {
+            optedOut.handleEvents(Event.Init)
+            coroutineRule.testScope.runCurrent()
+
+            assertTrue(optedOut.viewState.value.userBiometricsAreEnabled)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `init restores an active lockout and counts it down to release`() = coroutineRule.runTest {
+        whenever(interactor.getBiometricUserSelection()).thenReturn(false)
+        whenever(interactor.getPinLockoutState()).thenReturn(lockout(3.seconds))
+
+        viewModel.handleEvents(Event.Init)
+        coroutineRule.testScope.runCurrent()
+
+        assertTrue(viewModel.viewState.value.isLockedOut)
+        assertEquals("locked:$MAX_ATTEMPTS:00:03", viewModel.viewState.value.lockoutMessage)
+
+        coroutineRule.testScope.advanceTimeBy(1_500.milliseconds)
+        coroutineRule.testScope.runCurrent()
+
+        assertEquals("locked:$MAX_ATTEMPTS:00:02", viewModel.viewState.value.lockoutMessage)
+
+        coroutineRule.testScope.advanceUntilIdle()
+
+        assertFalse(viewModel.viewState.value.isLockedOut)
+        assertNull(viewModel.viewState.value.lockoutMessage)
+    }
+
+    @Test
+    fun `init releases a lockout that has already expired`() = coroutineRule.runTest {
+        whenever(interactor.getBiometricUserSelection()).thenReturn(false)
+        whenever(interactor.getPinLockoutState()).thenReturn(lockout(Duration.ZERO))
+
+        viewModel.handleEvents(Event.Init)
+        coroutineRule.testScope.runCurrent()
+
+        assertFalse(viewModel.viewState.value.isLockedOut)
+        assertNull(viewModel.viewState.value.lockoutMessage)
+    }
+
+    @Test
+    fun `launching the system screen clears the error and delegates to the interactor`() =
+        coroutineRule.runTest {
+            viewModel.handleEvents(click)
+            completeAuthentication(BiometricsAuthenticate.Failed("Locked sensor"))
+            assertNotNull(viewModel.viewState.value.error)
+
+            viewModel.handleEvents(Event.LaunchBiometricSystemScreen)
+
+            assertNull(viewModel.viewState.value.error)
+            verify(interactor).launchBiometricSystemScreen()
+        }
+
+    @Test
+    fun `back navigation reports the flow as cancelled`() = coroutineRule.runTest {
+        val backable = newViewModel(
+            "backable",
+            config(
+                onBackNavigation = ConfigNavigation(
+                    navigationType = NavigationType.PopTo(DashboardScreens.Dashboard),
+                    indicateFlowCompletion = FlowCompletion.CANCEL
+                )
+            )
+        )
+
+        backable.effect.runFlowTest {
+            backable.handleEvents(Event.OnNavigateBack)
+
+            assertEquals(
+                Effect.Navigation.PopBackStackUpTo(
+                    screenRoute = DashboardScreens.Dashboard.screenRoute,
+                    inclusive = false,
+                    indicateFlowCompletion = FlowCompletion.CANCEL
+                ),
+                awaitItem()
+            )
+        }
+    }
+
+    @Test
+    fun `back navigation does not report success completion for a cancelled flow`() =
+        coroutineRule.runTest {
+            val backable = newViewModel(
+                "backableSuccess",
+                config(
+                    onBackNavigation = ConfigNavigation(
+                        navigationType = NavigationType.PopTo(DashboardScreens.Dashboard),
+                        indicateFlowCompletion = FlowCompletion.SUCCESS
+                    )
+                )
+            )
+
+            backable.effect.runFlowTest {
+                backable.handleEvents(Event.OnNavigateBack)
+
+                assertEquals(
+                    Effect.Navigation.PopBackStackUpTo(
+                        screenRoute = DashboardScreens.Dashboard.screenRoute,
+                        inclusive = false,
+                        indicateFlowCompletion = FlowCompletion.NONE
+                    ),
+                    awaitItem()
+                )
+            }
+        }
+
+    @Test
+    fun `back navigation emits nothing when no route is configured`() = coroutineRule.runTest {
+        viewModel.effect.runFlowTest {
+            viewModel.handleEvents(Event.OnNavigateBack)
+            coroutineRule.testScope.runCurrent()
+
+            assertNull(viewModel.viewState.value.error)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    @Suppress("UnusedFlow")
+    fun `pin entry is discarded while locked out`() = coroutineRule.runTest {
+        lockViewModelOut()
+        val pin = SecurePinImpl("123456")
+
+        viewModel.handleEvents(Event.OnQuickPinEntered(pin))
+
+        assertTrue(pin.isCleared)
+        verify(interactor, never()).isPinValid(any())
+    }
+
+    @Test
+    fun `pin length changes are ignored while locked out`() = coroutineRule.runTest {
+        lockViewModelOut()
+
+        viewModel.handleEvents(Event.OnQuickPinLengthChanged(3))
+
+        assertTrue(viewModel.viewState.value.isLockedOut)
+        assertEquals("locked:$MAX_ATTEMPTS:00:30", viewModel.viewState.value.lockoutMessage)
+    }
+
+    @Test
+    fun `changing the pin length clears the previous pin error`() = coroutineRule.runTest {
+        whenever(interactor.recordPinFailure()).thenReturn(PinLockoutState.Idle)
+
+        val pin = enterPin("123456", QuickPinInteractorPinValidPartialState.Failed("Wrong PIN"))
+        assertEquals("Wrong PIN", viewModel.viewState.value.quickPinError)
+
+        viewModel.handleEvents(Event.OnQuickPinLengthChanged(3))
+
+        assertNull(viewModel.viewState.value.quickPinError)
+
+        pin.close()
+    }
+
+    @Test
+    @Suppress("UnusedFlow")
+    fun `an incomplete pin is discarded without validation`() = coroutineRule.runTest {
+        val pin = SecurePinImpl("123")
+
+        viewModel.handleEvents(Event.OnQuickPinEntered(pin))
+
+        assertTrue(pin.isCleared)
+        assertFalse(viewModel.viewState.value.isLoading)
+        verify(interactor, never()).isPinValid(any())
+    }
+
+    @Test
+    fun `a wrong pin surfaces the error while attempts remain`() = coroutineRule.runTest {
+        whenever(interactor.recordPinFailure()).thenReturn(PinLockoutState.Idle)
+
+        val pin = enterPin("123456", QuickPinInteractorPinValidPartialState.Failed("Wrong PIN"))
+
+        assertEquals("Wrong PIN", viewModel.viewState.value.quickPinError)
+        assertFalse(viewModel.viewState.value.isLoading)
+        assertFalse(viewModel.viewState.value.isLockedOut)
+
+        pin.close()
+    }
+
+    @Test
+    fun `a wrong pin that exhausts the attempts starts the lockout`() = coroutineRule.runTest {
+        whenever(interactor.recordPinFailure()).thenReturn(lockout(30.seconds))
+
+        val pin = enterPin("123456", QuickPinInteractorPinValidPartialState.Failed("Wrong PIN"))
+
+        assertTrue(viewModel.viewState.value.isLockedOut)
+        assertFalse(viewModel.viewState.value.isLoading)
+        assertEquals("locked:$MAX_ATTEMPTS:00:30", viewModel.viewState.value.lockoutMessage)
+
+        pin.close()
+    }
+
+    @Test
+    fun `clearing the view model freezes the lockout state`() = coroutineRule.runTest {
+        lockViewModelOut()
+
+        store.clear()
+        coroutineRule.testScope.advanceUntilIdle()
+
+        assertTrue(viewModel.viewState.value.isLockedOut)
+        assertEquals("locked:$MAX_ATTEMPTS:00:30", viewModel.viewState.value.lockoutMessage)
+    }
+
+    @Test
+    fun `a successful authentication releases the re-entrancy guard`() = coroutineRule.runTest {
+        viewModel.effect.runFlowTest {
+            viewModel.handleEvents(click)
+            completeAuthentication(BiometricsAuthenticate.Success)
+            coroutineRule.testScope.runCurrent()
+
+            assertEquals(Effect.Navigation.Pop, awaitItem())
+
+            viewModel.handleEvents(click)
+
+            assertEquals(2, callbacks.size)
+        }
+    }
+
+    @Test
+    fun `a biometric failure can be dismissed from its own action`() = coroutineRule.runTest {
+        viewModel.handleEvents(click)
+        completeAuthentication(BiometricsAuthenticate.Failed("Locked sensor"))
+
+        assertNotNull(viewModel.viewState.value.error)
+
+        viewModel.viewState.value.error?.onCancel?.invoke()
+        coroutineRule.testScope.runCurrent()
+
+        assertNull(viewModel.viewState.value.error)
+    }
+
+    @Test
+    fun `an invalid configuration is rejected`() {
+        whenever(
+            serializer.fromBase64(
+                "broken",
+                BiometricUiConfig::class.java,
+                BiometricUiConfig.Parser
+            )
+        ).thenReturn(null)
+        val broken = BiometricViewModel(
+            biometricInteractor = interactor,
+            resourceProvider = resources,
+            uiSerializer = serializer,
+            biometricConfig = "broken"
+        ).also { store.put("broken", it) }
+
+        assertThrows(RuntimeException::class.java) { broken.viewState.value }
+    }
+
+    @Test
+    fun `success reports completion for a pop-to route`() = assertSuccessNavigation(
+        key = "popToSuccess",
+        navigation = ConfigNavigation(
+            navigationType = NavigationType.PopTo(DashboardScreens.Dashboard),
+            indicateFlowCompletion = FlowCompletion.SUCCESS
+        ),
+        expected = Effect.Navigation.PopBackStackUpTo(
+            screenRoute = DashboardScreens.Dashboard.screenRoute,
+            inclusive = false,
+            indicateFlowCompletion = FlowCompletion.SUCCESS
+        )
+    )
+
+    @Test
+    fun `success does not report cancellation for a pop-to route`() = assertSuccessNavigation(
+        key = "popToCancel",
+        navigation = ConfigNavigation(
+            navigationType = NavigationType.PopTo(DashboardScreens.Dashboard),
+            indicateFlowCompletion = FlowCompletion.CANCEL
+        ),
+        expected = Effect.Navigation.PopBackStackUpTo(
+            screenRoute = DashboardScreens.Dashboard.screenRoute,
+            inclusive = false,
+            indicateFlowCompletion = FlowCompletion.NONE
+        )
+    )
+
+    @Test
+    fun `success reports no completion when none is configured`() = assertSuccessNavigation(
+        key = "popToNone",
+        navigation = ConfigNavigation(
+            navigationType = NavigationType.PopTo(DashboardScreens.Dashboard),
+            indicateFlowCompletion = FlowCompletion.NONE
+        ),
+        expected = Effect.Navigation.PopBackStackUpTo(
+            screenRoute = DashboardScreens.Dashboard.screenRoute,
+            inclusive = false,
+            indicateFlowCompletion = FlowCompletion.NONE
+        )
+    )
+
+    @Test
+    fun `success pushes the configured screen with its arguments`() = assertSuccessNavigation(
+        key = "pushScreen",
+        navigation = ConfigNavigation(
+            navigationType = NavigationType.PushScreen(
+                screen = CommonScreens.QuickPin,
+                arguments = mapOf("pinFlow" to "UPDATE")
+            )
+        ),
+        expected = Effect.Navigation.SwitchScreen(
+            screen = "${CommonScreens.QuickPin.screenName}?pinFlow=UPDATE",
+            screenPopUpTo = CommonScreens.Biometric.screenRoute
+        )
+    )
+
+    @Test
+    fun `success pushes the configured raw route`() = assertSuccessNavigation(
+        key = "pushRoute",
+        navigation = ConfigNavigation(navigationType = NavigationType.PushRoute(route = "RAW_ROUTE")),
+        expected = Effect.Navigation.SwitchScreen(
+            screen = "RAW_ROUTE",
+            screenPopUpTo = CommonScreens.Biometric.screenRoute
+        )
+    )
+
+    @Test
+    fun `success finishes the host when configured`() = assertSuccessNavigation(
+        key = "finish",
+        navigation = ConfigNavigation(navigationType = NavigationType.Finish),
+        expected = Effect.Navigation.Finish
+    )
+
+    @Test
+    fun `success forwards a deeplink together with the pre authorization flag`() =
+        coroutineRule.runTest {
+            val navigation = ConfigNavigation(
+                navigationType = NavigationType.Deeplink(
+                    link = DEEPLINK,
+                    routeToPop = DashboardScreens.Dashboard.screenRoute
+                )
+            )
+            val vm = newViewModel(
+                "deeplink",
+                config(onSuccessNavigation = navigation, isPreAuthorization = true)
+            )
+
+            vm.effect.runFlowTest {
+                vm.handleEvents(Event.OnBiometricsClicked(context, true))
+                callbacks.last().invoke(BiometricsAuthenticate.Success)
+                coroutineRule.testScope.runCurrent()
+
+                assertEquals(
+                    Effect.Navigation.Deeplink(
+                        link = DEEPLINK.toUri(),
+                        isPreAuthorization = true,
+                        routeToPop = DashboardScreens.Dashboard.screenRoute
+                    ),
+                    awaitItem()
+                )
+            }
+        }
+
     private fun completeAuthentication(result: BiometricsAuthenticate) {
         callbacks.single().invoke(result)
+    }
+
+    private fun assertSuccessNavigation(
+        key: String,
+        navigation: ConfigNavigation,
+        expected: Effect,
+    ) = coroutineRule.runTest {
+        val vm = newViewModel(key, config(onSuccessNavigation = navigation))
+
+        vm.effect.runFlowTest {
+            vm.handleEvents(Event.OnBiometricsClicked(context, true))
+            callbacks.last().invoke(BiometricsAuthenticate.Success)
+            coroutineRule.testScope.runCurrent()
+
+            assertEquals(expected, awaitItem())
+        }
+    }
+
+    private suspend fun lockViewModelOut(remaining: Duration = 30.seconds) {
+        whenever(interactor.getBiometricUserSelection()).thenReturn(false)
+        whenever(interactor.getPinLockoutState()).thenReturn(lockout(remaining))
+
+        viewModel.handleEvents(Event.Init)
+        coroutineRule.testScope.runCurrent()
+    }
+
+    private fun enterPin(
+        pin: String,
+        result: QuickPinInteractorPinValidPartialState
+    ): SecurePinImpl {
+        val securePin = SecurePinImpl(pin)
+        whenever(interactor.isPinValid(securePin)).thenReturn(flowOf(result))
+
+        viewModel.handleEvents(Event.OnQuickPinEntered(securePin))
+        coroutineRule.testScope.runCurrent()
+        return securePin
+    }
+
+    private fun lockout(remaining: Duration) =
+        PinLockoutState.Active(remaining = remaining, total = 30.seconds)
+
+    private fun config(
+        shouldInitializeBiometricAuthOnCreate: Boolean = true,
+        isPreAuthorization: Boolean = false,
+        onSuccessNavigation: ConfigNavigation = ConfigNavigation(NavigationType.Pop),
+        onBackNavigation: ConfigNavigation? = null,
+    ) = BiometricUiConfig(
+        mode = BiometricMode.Login("Welcome", "Biometrics", "PIN"),
+        isPreAuthorization = isPreAuthorization,
+        shouldInitializeBiometricAuthOnCreate = shouldInitializeBiometricAuthOnCreate,
+        onSuccessNavigation = onSuccessNavigation,
+        onBackNavigationConfig = OnBackNavigationConfig(
+            onBackNavigation = onBackNavigation,
+            hasToolbarBackIcon = onBackNavigation != null
+        )
+    )
+
+    private fun newViewModel(key: String, config: BiometricUiConfig): BiometricViewModel {
+        whenever(
+            serializer.fromBase64(key, BiometricUiConfig::class.java, BiometricUiConfig.Parser)
+        ).thenReturn(config)
+        return BiometricViewModel(
+            biometricInteractor = interactor,
+            resourceProvider = resources,
+            uiSerializer = serializer,
+            biometricConfig = key
+        ).also { store.put(key, it) }
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 5
+        const val DEEPLINK = "https://example.org/deeplink"
     }
 }

--- a/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/ui/settings/TestSettingsViewModel.kt
+++ b/dashboard-feature/src/test/java/eu/europa/ec/dashboardfeature/ui/settings/TestSettingsViewModel.kt
@@ -17,12 +17,17 @@
 package eu.europa.ec.dashboardfeature.ui.settings
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.IntentCompat
+import androidx.core.net.toUri
 import androidx.lifecycle.ViewModelStore
 import eu.europa.ec.authenticationlogic.controller.authentication.BiometricsAuthenticate
 import eu.europa.ec.authenticationlogic.controller.authentication.BiometricsAvailability
 import eu.europa.ec.dashboardfeature.interactor.SettingsInteractor
 import eu.europa.ec.dashboardfeature.ui.settings.model.SettingsItemUi
 import eu.europa.ec.dashboardfeature.ui.settings.model.SettingsMenuItemType
+import eu.europa.ec.resourceslogic.R
 import eu.europa.ec.resourceslogic.provider.ResourceProvider
 import eu.europa.ec.testlogic.extension.runFlowTest
 import eu.europa.ec.testlogic.extension.runTest
@@ -31,6 +36,8 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runCurrent
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -79,6 +86,10 @@ class TestSettingsViewModel {
         click = Event.ItemClicked(SettingsMenuItemType.BIOMETRICS_AUTHENTICATION, context)
 
         whenever(resources.getString(any())).thenReturn("Settings")
+        whenever(resources.getString(R.string.settings_screen_option_registration_check_restart))
+            .thenReturn(RESTART_STRING)
+        whenever(resources.getString(R.string.settings_intent_chooser_logs_share_title))
+            .thenReturn(LOGS_CHOOSER_TITLE)
         whenever(interactor.getAppVersion()).thenReturn("test")
         whenever(interactor.getBiometricsAvailability())
             .thenReturn(BiometricsAvailability.CanAuthenticate)
@@ -214,7 +225,160 @@ class TestSettingsViewModel {
         }
     }
 
+    @Test
+    fun `init shows a loading pass before publishing the settings items`() =
+        coroutineRule.runTest {
+            val items = listOf(settingsItem)
+            val released = CompletableDeferred<Unit>()
+            whenever(interactor.getSettingsItemsUi(null)).doSuspendableAnswer {
+                released.await()
+                items
+            }
+
+            viewModel.handleEvents(Event.Init)
+            coroutineRule.testScope.runCurrent()
+
+            assertTrue(viewModel.viewState.value.isLoading)
+            assertEquals(emptyList<SettingsItemUi>(), viewModel.viewState.value.settingsItems)
+
+            released.complete(Unit)
+            coroutineRule.testScope.runCurrent()
+
+            assertFalse(viewModel.viewState.value.isLoading)
+            assertEquals(items, viewModel.viewState.value.settingsItems)
+        }
+
+    @Test
+    fun `pop requests navigation back`() = coroutineRule.runTest {
+        viewModel.effect.runFlowTest {
+            viewModel.handleEvents(Event.Pop)
+
+            assertEquals(Effect.Navigation.Pop, awaitItem())
+        }
+    }
+
+    @Test
+    fun `launch biometric system screen delegates to the interactor`() = coroutineRule.runTest {
+        viewModel.handleEvents(Event.LaunchBiometricSystemScreen)
+
+        verify(interactor).launchBiometricSystemScreen()
+        assertEquals(0, callbacks.size)
+    }
+
+    @Test
+    fun `toggling the batch issuance counter refreshes the settings items`() =
+        coroutineRule.runTest {
+            val updatedItems = listOf(settingsItem)
+            whenever(interactor.getSettingsItemsUi(null)).thenReturn(updatedItems)
+
+            viewModel.handleEvents(
+                Event.ItemClicked(SettingsMenuItemType.SHOW_BATCH_ISSUANCE_COUNTER, context)
+            )
+            coroutineRule.testScope.runCurrent()
+
+            verify(interactor).toggleShowBatchIssuanceCounter()
+            assertEquals(updatedItems, viewModel.viewState.value.settingsItems)
+            verify(interactor, never()).authenticateWithBiometrics(any(), any(), any())
+        }
+
+    @Test
+    fun `toggling the registration check refreshes the items and asks for a restart`() =
+        coroutineRule.runTest {
+            val updatedItems = listOf(settingsItem)
+            whenever(interactor.getSettingsItemsUi(null)).thenReturn(updatedItems)
+
+            viewModel.effect.runFlowTest {
+                viewModel.handleEvents(
+                    Event.ItemClicked(SettingsMenuItemType.REGISTRATION_CHECK, context)
+                )
+                coroutineRule.testScope.runCurrent()
+
+                verify(interactor).toggleRegistrationCheck()
+                assertEquals(updatedItems, viewModel.viewState.value.settingsItems)
+                assertEquals(Effect.ShowSnackbar(RESTART_STRING), awaitItem())
+            }
+        }
+
+    @Test
+    fun `retrieving logs shares every log file`() = coroutineRule.runTest {
+        val logs = arrayListOf("content://logs/1".toUri(), "content://logs/2".toUri())
+        whenever(interactor.retrieveLogFileUris()).thenReturn(logs)
+
+        viewModel.effect.runFlowTest {
+            viewModel.handleEvents(Event.ItemClicked(SettingsMenuItemType.RETRIEVE_LOGS, context))
+
+            val effect = awaitItem()
+            assertTrue(effect is Effect.ShareLogFile)
+            val shareLogFile = effect as Effect.ShareLogFile
+            assertEquals(Intent.ACTION_SEND_MULTIPLE, shareLogFile.intent.action)
+            assertEquals("text/*", shareLogFile.intent.type)
+            assertEquals(LOGS_CHOOSER_TITLE, shareLogFile.chooserTitle)
+            assertEquals(
+                logs,
+                IntentCompat.getParcelableArrayListExtra(
+                    shareLogFile.intent,
+                    Intent.EXTRA_STREAM,
+                    Uri::class.java
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `retrieving logs stays silent when there is nothing to share`() = coroutineRule.runTest {
+        whenever(interactor.retrieveLogFileUris()).thenReturn(arrayListOf())
+
+        viewModel.effect.runFlowTest {
+            viewModel.handleEvents(Event.ItemClicked(SettingsMenuItemType.RETRIEVE_LOGS, context))
+            coroutineRule.testScope.runCurrent()
+
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `changelog opens the configured url externally`() = coroutineRule.runTest {
+        whenever(interactor.getChangelogUrl()).thenReturn(CHANGELOG_URL)
+        val withChangelog = newViewModel("withChangelog")
+
+        withChangelog.effect.runFlowTest {
+            withChangelog.handleEvents(Event.ItemClicked(SettingsMenuItemType.CHANGELOG, context))
+
+            assertEquals(
+                Effect.Navigation.OpenUrlExternally(CHANGELOG_URL.toUri()),
+                awaitItem()
+            )
+        }
+    }
+
+    @Test
+    fun `changelog stays silent when no url is configured`() = coroutineRule.runTest {
+        whenever(interactor.getChangelogUrl()).thenReturn(null)
+        val withoutChangelog = newViewModel("withoutChangelog")
+
+        withoutChangelog.effect.runFlowTest {
+            withoutChangelog.handleEvents(
+                Event.ItemClicked(SettingsMenuItemType.CHANGELOG, context)
+            )
+            coroutineRule.testScope.runCurrent()
+
+            expectNoEvents()
+        }
+    }
+
     private fun completeAuthentication(result: BiometricsAuthenticate) {
         callbacks.single().invoke(result)
+    }
+
+    private fun newViewModel(key: String): SettingsViewModel = SettingsViewModel(
+        settingsInteractor = interactor,
+        resourceProvider = resources
+    ).also { store.put(key, it) }
+
+    private companion object {
+        const val SETTINGS_STRING = "Settings"
+        const val RESTART_STRING = "Restart required"
+        const val LOGS_CHOOSER_TITLE = "Share logs"
+        const val CHANGELOG_URL = "https://example.org/changelog"
     }
 }


### PR DESCRIPTION
Expand unit test coverage across biometric authentication and settings features:
- Added comprehensive unit tests for `BiometricViewModel` covering biometric availability, initialization, PIN lockout states, back navigation, success navigation flows, and error handling.
- Added unit tests for `SettingsViewModel` verifying initialization, setting toggles (batch issuance counter, registration check), log sharing, changelog handling, and back navigation.
- Reordered internal helper functions in `BiometricAuthenticationController`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [x] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
